### PR TITLE
Pull in ClowderConfigSource

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -33,3 +33,8 @@ If you want to build an _über-jar_, execute the following command:
 ----
 
 The application is now runnable using `java -jar target/notifications-gw-1.0.0-SNAPSHOT-runner.jar`.
+
+## Usage of the Clowder Config Source
+
+This project uses the Clowder Config Source from https://github.com/RedHatInsights/clowder-quarkus-config-source To configure this source to use
+a different file than `/cdappconfig/cdappconfig.json` you can use the property `clowder.file=/path/to/file.json`.

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
     <testcontainers.version>1.15.1</testcontainers.version>
     <mockserver-client-java.version>5.5.4</mockserver-client-java.version> <!-- not the newest, but matches what is in org.testcontainers:mockserver -->
     <insights-notification-schemas-java.version>0.2</insights-notification-schemas-java.version>
+    <clowder-quarkus-config-source.version>0.1.1</clowder-quarkus-config-source.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -87,6 +88,11 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-hibernate-validator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.redhat.cloud.common</groupId>
+      <artifactId>clowder-quarkus-config-source</artifactId>
+      <version>${clowder-quarkus-config-source.version}</version>
     </dependency>
 
     <dependency>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,4 @@
+
 # Kafka bootstrap applies to all topics
 kafka.bootstrap.servers=localhost:9092
 


### PR DESCRIPTION
This is an alternative version on #14 where the config source (factory) is coming from its own project.
This will only work once https://github.com/RedHatInsights/clowder-quarkus-config-source/pull/1 is merged and released to central (or from local build).


cc @bennetelli @radcortez