### PR TITLE
Change QUARKUS_HTTP_PORT to 8000 for Clowder

### DIFF
--- a/.rhcicd/clowdapp.yaml
+++ b/.rhcicd/clowdapp.yaml
@@ -54,6 +54,8 @@ objects:
           value: ${LOG_LEVEL}
         - name: QUARKUS_LOG_CLOUDWATCH_ENABLED
           value: ${CLOUDWATCH_LOGGING_ENABLED}
+        - name: QUARKUS_HTTP_PORT
+          value: "8000"
         resources:
           limits:
             cpu: ${CPU_LIMIT}


### PR DESCRIPTION
This is required for the stage deployment with Clowder.