### PR TITLE
NOTIF-310 Allows recipients settings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <surefire-plugin.version>2.22.2</surefire-plugin.version>
     <testcontainers.version>1.16.2</testcontainers.version>
     <mockserver-client-java.version>5.5.4</mockserver-client-java.version> <!-- not the newest, but matches what is in org.testcontainers:mockserver -->
-    <insights-notification-schemas-java.version>0.3</insights-notification-schemas-java.version>
+    <insights-notification-schemas-java.version>0.4</insights-notification-schemas-java.version>
     <clowder-quarkus-config-source.version>0.2.2</clowder-quarkus-config-source.version>
   </properties>
   <dependencyManagement>

--- a/src/main/java/com/redhat/cloud/notifications/GwResource.java
+++ b/src/main/java/com/redhat/cloud/notifications/GwResource.java
@@ -4,6 +4,7 @@ import com.redhat.cloud.notifications.ingress.Action;
 import com.redhat.cloud.notifications.ingress.Event;
 import com.redhat.cloud.notifications.ingress.Metadata;
 
+import com.redhat.cloud.notifications.ingress.Recipient;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.smallrye.reactive.messaging.kafka.api.OutgoingKafkaRecordMetadata;
@@ -83,10 +84,24 @@ public class GwResource {
         for (RestEvent restEvent : events) {
             Metadata.Builder metadataBuilder = Metadata.newBuilder();
             Event event = new Event(metadataBuilder.build(), restEvent.getPayload());
-            eventList.add(event);    
+            eventList.add(event);
         }
-          
+
+        List<Recipient> recipientList = new ArrayList<>(1);
+        List<RestRecipient> recipients = ra.getRecipients();
+        if (recipients != null) {
+            for (RestRecipient restRecipient : recipients) {
+                Recipient.Builder recipientBuilder = Recipient.newBuilder();
+                Recipient recipient = recipientBuilder
+                        .setIgnoreUserPreferences(restRecipient.isIgnoreUserPreferences())
+                        .setOnlyAdmins(restRecipient.isOnlyAdmins())
+                        .build();
+                recipientList.add(recipient);
+            }
+        }
+
         builder.setEvents(eventList);
+        builder.setRecipients(recipientList);
         builder.setEventType(ra.eventType);
         builder.setApplication(ra.application);
         builder.setBundle(ra.bundle);

--- a/src/main/java/com/redhat/cloud/notifications/GwResource.java
+++ b/src/main/java/com/redhat/cloud/notifications/GwResource.java
@@ -79,15 +79,15 @@ public class GwResource {
         Action.Builder builder = Action.newBuilder();
         LocalDateTime parsedTime = LocalDateTime.parse(ra.timestamp, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
         builder.setTimestamp(parsedTime);
-        List<Event> eventList = new ArrayList<>(1);
         List<RestEvent> events = ra.getEvents();
+        List<Event> eventList = new ArrayList<>(events.size());
         for (RestEvent restEvent : events) {
             Metadata.Builder metadataBuilder = Metadata.newBuilder();
             Event event = new Event(metadataBuilder.build(), restEvent.getPayload());
             eventList.add(event);
         }
 
-        List<Recipient> recipientList = new ArrayList<>(1);
+        List<Recipient> recipientList = new ArrayList<>();
         List<RestRecipient> recipients = ra.getRecipients();
         if (recipients != null) {
             for (RestRecipient restRecipient : recipients) {

--- a/src/main/java/com/redhat/cloud/notifications/RestAction.java
+++ b/src/main/java/com/redhat/cloud/notifications/RestAction.java
@@ -61,6 +61,7 @@ public class RestAction {
 
     public Map<String, Object> context;
 
+    public List<RestRecipient> recipients;
 
     public String getBundle() {
         return bundle;
@@ -116,5 +117,13 @@ public class RestAction {
 
     public void setContext(Map<String, Object> context) {
         this.context = context;
+    }
+
+    public List<RestRecipient> getRecipients() {
+        return recipients;
+    }
+
+    public void setRecipients(List<RestRecipient> recipients) {
+        this.recipients = recipients;
     }
 }

--- a/src/main/java/com/redhat/cloud/notifications/RestRecipient.java
+++ b/src/main/java/com/redhat/cloud/notifications/RestRecipient.java
@@ -1,8 +1,13 @@
 package com.redhat.cloud.notifications;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class RestRecipient {
 
+    @JsonProperty("ignore_user_preferences")
     private boolean ignoreUserPreferences;
+
+    @JsonProperty("only_admins")
     private boolean onlyAdmins;
 
     public boolean isIgnoreUserPreferences() {

--- a/src/main/java/com/redhat/cloud/notifications/RestRecipient.java
+++ b/src/main/java/com/redhat/cloud/notifications/RestRecipient.java
@@ -1,0 +1,23 @@
+package com.redhat.cloud.notifications;
+
+public class RestRecipient {
+
+    private boolean ignoreUserPreferences;
+    private boolean onlyAdmins;
+
+    public boolean isIgnoreUserPreferences() {
+        return ignoreUserPreferences;
+    }
+
+    public void setIgnoreUserPreferences(boolean ignoreUserPreferences) {
+        this.ignoreUserPreferences = ignoreUserPreferences;
+    }
+
+    public boolean isOnlyAdmins() {
+        return onlyAdmins;
+    }
+
+    public void setOnlyAdmins(boolean onlyAdmins) {
+        this.onlyAdmins = onlyAdmins;
+    }
+}

--- a/src/test/java/com/redhat/cloud/notifications/GwResourceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/GwResourceTest.java
@@ -111,7 +111,6 @@ public class GwResourceTest {
 
         List<Map> recipientList = (List<Map>) am.get("recipients");
         assertEquals(2, recipientList.size());
-        System.out.println(recipientList.get(0));
         Map<String, Object> r0 = recipientList.get(0);
         assertEquals(Boolean.TRUE, r0.get("only_admins"));
         assertEquals(Boolean.FALSE, r0.get("ignore_user_preferences"));


### PR DESCRIPTION
This goes with https://github.com/RedHatInsights/notifications-backend/pull/595

Backwards compatibility is keep in the API (i.e. does not break if you don't send `recipients` settings)