### PR TITLE
NOTIF-336 Fix clowdapp.yaml deployment name

### DIFF
--- a/.rhcicd/clowdapp.yaml
+++ b/.rhcicd/clowdapp.yaml
@@ -17,7 +17,7 @@ objects:
       partitions: 3
       replicas: 3
     deployments:
-    - name: notifications-gw
+    - name: service
       minReplicas: ${{MIN_REPLICAS}}
       web: true
       podSpec:


### PR DESCRIPTION
This is the preferred deployment naming which is already used in most migrated Clowdapps.