### PR TITLE
Add notifications-backend in the ClowdApp dependencies

### DIFF
--- a/.rhcicd/clowdapp.yaml
+++ b/.rhcicd/clowdapp.yaml
@@ -12,6 +12,8 @@ objects:
       app: notifications-gw
   spec:
     envName: ${ENV_NAME}
+    dependencies:
+    - notifications-backend
     kafkaTopics:
     - topicName: platform.notifications.ingress
       partitions: 3


### PR DESCRIPTION
The deployment failed on stage because of the missing dependency.