### PR TITLE
Use the new Quarkus Log API

### DIFF
--- a/src/main/java/com/redhat/cloud/notifications/GwResource.java
+++ b/src/main/java/com/redhat/cloud/notifications/GwResource.java
@@ -18,7 +18,6 @@ import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.reactive.messaging.Emitter;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
-import org.jboss.logging.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -44,8 +43,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
 public class GwResource {
-
-    private static final Logger LOG = Logger.getLogger(NotificationsGwApp.class);
 
     public static final String EGRESS_CHANNEL = "egress";
     public static final String MESSAGE_ID_HEADER = "rh-message-id";

--- a/src/main/java/com/redhat/cloud/notifications/NotificationsGwApp.java
+++ b/src/main/java/com/redhat/cloud/notifications/NotificationsGwApp.java
@@ -16,6 +16,7 @@
  */
 package com.redhat.cloud.notifications;
 
+import io.quarkus.logging.Log;
 import io.quarkus.runtime.StartupEvent;
 
 import java.io.BufferedReader;
@@ -27,7 +28,6 @@ import java.util.regex.Pattern;
 
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.jboss.logging.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
@@ -46,14 +46,12 @@ public class NotificationsGwApp {
     @ConfigProperty(name = "quarkus.http.access-log.category")
     private String loggerName;
 
-    private static final Logger LOG = Logger.getLogger(NotificationsGwApp.class);
-
     void init(@Observes StartupEvent ev) {
         initAccessLogFilter();
 
-        LOG.info(readGitProperties());
+        Log.info(readGitProperties());
 
-        LOG.infof("quarkus.rest-client.notifications-backend.url" + "=%s", ConfigProvider.getConfig().getValue(NOTIFICATIONS_URL_KEY, String.class));
+        Log.infof("quarkus.rest-client.notifications-backend.url" + "=%s", ConfigProvider.getConfig().getValue(NOTIFICATIONS_URL_KEY, String.class));
     }
 
     private void initAccessLogFilter() {
@@ -71,7 +69,7 @@ public class NotificationsGwApp {
         try {
             return readFromInputStream(inputStream);
         } catch (IOException e) {
-            LOG.log(Logger.Level.ERROR, "Could not read git.properties.", e);
+            Log.error("Could not read git.properties.", e);
             return "Version information could not be retrieved";
         }
     }

--- a/src/main/java/com/redhat/cloud/notifications/auth/RHIdAuthMechanism.java
+++ b/src/main/java/com/redhat/cloud/notifications/auth/RHIdAuthMechanism.java
@@ -16,6 +16,7 @@
  */
 package com.redhat.cloud.notifications.auth;
 
+import io.quarkus.logging.Log;
 import io.quarkus.security.identity.IdentityProviderManager;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.security.identity.request.AuthenticationRequest;
@@ -25,7 +26,6 @@ import io.quarkus.vertx.http.runtime.security.HttpAuthenticationMechanism;
 import io.quarkus.vertx.http.runtime.security.HttpCredentialTransport;
 import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
-import org.jboss.logging.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
 import java.util.Collections;
@@ -41,7 +41,6 @@ import java.util.Set;
 public class RHIdAuthMechanism implements HttpAuthenticationMechanism {
 
     public static final String IDENTITY_HEADER = "x-rh-identity";
-    private static final Logger LOG = Logger.getLogger(RHIdAuthMechanism.class);
 
     @Override
     public Uni<SecurityIdentity> authenticate(RoutingContext context, IdentityProviderManager identityProviderManager) {
@@ -55,9 +54,7 @@ public class RHIdAuthMechanism implements HttpAuthenticationMechanism {
             subject = xid.getSubject();
         }
 
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Using subject " + subject);
-        }
+        Log.debugf("Using subject %s", subject);
 
         return Uni.createFrom().item(
                 QuarkusSecurityIdentity.builder()

--- a/src/main/java/com/redhat/cloud/notifications/clowder/KafkaSaslInitializer.java
+++ b/src/main/java/com/redhat/cloud/notifications/clowder/KafkaSaslInitializer.java
@@ -1,9 +1,9 @@
 package com.redhat.cloud.notifications.clowder;
 
+import io.quarkus.logging.Log;
 import io.quarkus.runtime.StartupEvent;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
-import org.jboss.logging.Logger;
 
 import javax.annotation.Priority;
 import javax.enterprise.context.ApplicationScoped;
@@ -19,7 +19,6 @@ import static javax.interceptor.Interceptor.Priority.PLATFORM_BEFORE;
 @ApplicationScoped
 public class KafkaSaslInitializer {
 
-    private static final Logger LOGGER = Logger.getLogger(KafkaSaslInitializer.class);
     private static final String KAFKA_SASL_JAAS_CONFIG = "kafka.sasl.jaas.config";
     private static final String KAFKA_SASL_MECHANISM = "kafka.sasl.mechanism";
     private static final String KAFKA_SECURITY_PROTOCOL = "kafka.security.protocol";
@@ -35,7 +34,7 @@ public class KafkaSaslInitializer {
         Optional<String> kafkaSslTruststoreType = config.getOptionalValue(KAFKA_SSL_TRUSTSTORE_TYPE, String.class);
 
         if (kafkaSaslJaasConfig.isPresent() || kafkaSaslMechanism.isPresent() || kafkaSecurityProtocol.isPresent() || kafkaSslTruststoreLocation.isPresent() || kafkaSslTruststoreType.isPresent()) {
-            LOGGER.info("Initializing Kafka SASL configuration...");
+            Log.info("Initializing Kafka SASL configuration...");
             setValue(KAFKA_SASL_JAAS_CONFIG, kafkaSaslJaasConfig);
             setValue(KAFKA_SASL_MECHANISM, kafkaSaslMechanism);
             setValue(KAFKA_SECURITY_PROTOCOL, kafkaSecurityProtocol);
@@ -47,7 +46,7 @@ public class KafkaSaslInitializer {
     private static void setValue(String configKey, Optional<String> configValue) {
         configValue.ifPresent(value -> {
             System.setProperty(configKey, value);
-            LOGGER.infof("%s has been set", configKey);
+            Log.infof("%s has been set", configKey);
         });
     }
 }


### PR DESCRIPTION
Quarkus recently introduced a new `Log` API which delegates all its invocations to `org.jboss.logging.Logger`. Building the logger is no longer needed.