### PR TITLE
Stop starting the app with io.fabric8:run-java-sh

### DIFF
--- a/src/main/docker/Dockerfile-build.jvm
+++ b/src/main/docker/Dockerfile-build.jvm
@@ -13,11 +13,9 @@ RUN ./mvnw clean package -DskipTests --no-transfer-progress
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 ARG JAVA_PACKAGE=java-11-openjdk-headless
-ARG RUN_JAVA_VERSION=1.3.8
-
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 
-# Install java and the run-java script
+# Install java
 # Also set up permissions for user `1001`
 RUN microdnf install curl ca-certificates ${JAVA_PACKAGE} \
     && microdnf update \
@@ -26,17 +24,18 @@ RUN microdnf install curl ca-certificates ${JAVA_PACKAGE} \
     && chown 1001 /deployments \
     && chmod "g+rwX" /deployments \
     && chown 1001:root /deployments \
-    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
-    && chown 1001 /deployments/run-java.sh \
-    && chmod 540 /deployments/run-java.sh \
     && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
 
 # Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
-ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -XX:+ExitOnOutOfMemoryError"
 
-COPY --from=build --chown=1001 /home/jboss/target/quarkus-app/ /deployments/
+# Use four distinct layers so if there are application changes the library layers can be re-used
+COPY --from=build --chown=1001 /home/jboss/target/quarkus-app/lib/ /deployments/lib/
+COPY --from=build --chown=1001 /home/jboss/target/quarkus-app/*.jar /deployments/
+COPY --from=build --chown=1001 /home/jboss/target/quarkus-app/app/ /deployments/app/
+COPY --from=build --chown=1001 /home/jboss/target/quarkus-app/quarkus/ /deployments/quarkus/
 
 EXPOSE 8080
 USER 1001
 
-ENTRYPOINT [ "/deployments/run-java.sh" ]
+ENTRYPOINT ["sh", "-c", "java $JAVA_OPTIONS -jar /deployments/quarkus-run.jar"]


### PR DESCRIPTION
All pods are down on stage and the Fabric8 script is missing a permission to run:
```
exec /deployments/run-java.sh: permission denied
```

![image](https://user-images.githubusercontent.com/10584698/182707435-bd9ef636-138e-42d3-8e5c-049a69bf1c21.png)

I don't know what caused that but we stopped using `run-java-sh` a long time ago in `notifications-backend` and we certainly don't need it in this project. This PR changes the Docker image generation to something almost identical to `notifications-backend`.