### PR TITLE
Rename do-nothing ClowdApp and job

### DIFF
--- a/.rhcicd/do-nothing.yaml
+++ b/.rhcicd/do-nothing.yaml
@@ -7,14 +7,14 @@ objects:
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdApp
   metadata:
-    name: notifications-gw-do-nothing-job-${IMAGE_TAG}
+    name: notifications-gw-do-nothing-${IMAGE_TAG}
     annotations:
       ignore-check.kube-linter.io/unset-cpu-requirements : "Not required for this job that does nothing"  
       ignore-check.kube-linter.io/unset-memory-requirements : "Not required for this job that does nothing"  
   spec:
     envName: ${ENV_NAME}
     jobs:
-    - name: do-nothing-gw
+    - name: job
       restartPolicy: Never
       schedule: "0 0 * * *"
       podSpec:


### PR DESCRIPTION
Fixes:
```
error creating resource *v1.CronJob notifications-gw-do-nothing-job-9402433-do-nothing-gw: CronJob.batch "notifications-gw-do-nothing-job-9402433-do-nothing-gw" is invalid: metadata.name: Invalid value: "notifications-gw-do-nothing-job-9402433-do-nothing-gw": must be no more than 52 characters
```