### PR TITLE
Require org_id

### DIFF
--- a/src/main/java/com/redhat/cloud/notifications/SamplesResource.java
+++ b/src/main/java/com/redhat/cloud/notifications/SamplesResource.java
@@ -31,7 +31,7 @@ public class SamplesResource {
         RestAction a = new RestAction();
         a.setId(UUID.fromString("1234fedb-1234-5678-9abc-f4af67cdf544"));
         a.setBundle("my-bundle");
-        a.setAccountId("123");
+        a.setOrgId("123");
         a.setOrgId("234567");
         a.setApplication("my-app");
         a.setEventType("a_type");

--- a/src/test/java/com/redhat/cloud/notifications/SamplesTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/SamplesTest.java
@@ -108,7 +108,7 @@ public class SamplesTest {
     @Test
     void testBad() {
         RestAction ra =new RestAction();
-        ra.accountId="123";
+        ra.orgId="123";
         ra.application="policies";
         ra.bundle="insights";
         ra.eventType="policy triggered";
@@ -126,7 +126,7 @@ public class SamplesTest {
     @Test
     void testBad2() {
         RestAction ra =new RestAction();
-        ra.accountId="123";
+        ra.orgId="123";
         ra.application="policies";
         ra.eventType="policy triggered";
         ra.timestamp="2020-12-18T17:04:04.417921";
@@ -144,7 +144,6 @@ public class SamplesTest {
     void testBadOrgId() {
         RestAction ra =new RestAction();
         ra.setOrgId("li la lu");
-        ra.accountId="123";
         ra.application="policies";
         ra.eventType="policy triggered";
         ra.timestamp="2020-12-18T17:04:04.417921";


### PR DESCRIPTION
While testing the default email - I noticed that the account id was still required here-
Switching to require the org_id and the set account_id  as optional