### PR TITLE
NOTIF-496 Return 400 when validating invalid b/a/et triplet

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit5-mockito</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/com/redhat/cloud/notifications/RestValidationClient.java
+++ b/src/main/java/com/redhat/cloud/notifications/RestValidationClient.java
@@ -1,24 +1,26 @@
 package com.redhat.cloud.notifications;
 
-import javax.ws.rs.Consumes;
+import javax.enterprise.context.ApplicationScoped;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+
 @Path("/internal/validation")
 @RegisterRestClient(configKey = "notifications-backend")
+@ApplicationScoped // This scope is required to mock the client during tests.
 public interface RestValidationClient {
 
     @GET
     @Path("/baet")
     @Retry(maxRetries = 5)
-    @Produces(MediaType.APPLICATION_JSON)
-    Response isBundleApplicationEventTypeTripleValid(@QueryParam("bundle") String bundle, @QueryParam("application") String application, @QueryParam("eventType") String eventType);
+    @Produces(TEXT_PLAIN)
+    Response validate(@QueryParam("bundle") String bundle, @QueryParam("application") String application, @QueryParam("eventType") String eventType);
 
 }


### PR DESCRIPTION
This is part 2.

See also [part 1](https://github.com/RedHatInsights/notifications-backend/pull/1519).