### PR TITLE
[RHCLOUD-22543] feature: parametrize the Sentry DSN

### DIFF
--- a/.rhcicd/clowdapp.yaml
+++ b/.rhcicd/clowdapp.yaml
@@ -73,7 +73,7 @@ objects:
         - name: QUARKUS_LOG_SENTRY
           value: ${SENTRY_ENABLED}
         - name: QUARKUS_LOG_SENTRY_DSN
-          value: https://04a2375b90274bf6a4bcb1d81f8d0e16@o271843.ingest.sentry.io/5826611?environment=${ENV_NAME}
+          value: ${SENTRY_DSN}${ENV_NAME}
         - name: QUARKUS_LOG_SENTRY_ENVIRONMENT
           value: ${ENV_NAME}
 parameters:
@@ -106,6 +106,8 @@ parameters:
 - name: NOTIFICATIONS_LOG_LEVEL
   description: Log level for com.redhat.cloud.notifications
   value: INFO
+- name: SENTRY_DSN
+  description: The DSN to push data to Sentry — i.e. https://public_key@host/project_id?environment=
 - name: SENTRY_ENABLED
   description: Enable Sentry (or not)
   value: "false"


### PR DESCRIPTION
This change will allow us to specify the Sentry DSN for the gateway on AppInterface.

## Links

[[RHCLOUD-22543]](https://issues.redhat.com/browse/RHCLOUD-22543)