### PR TITLE
Replace resteasy classic with resteasy reactive

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.version>3.4.3</quarkus.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+    <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <surefire-plugin.version>3.2.1</surefire-plugin.version>
     <testcontainers.version>1.19.1</testcontainers.version>
     <mockserver-netty-no-dependencies.version>5.15.0</mockserver-netty-no-dependencies.version>
@@ -34,43 +34,39 @@
     </dependencies>
   </dependencyManagement>
   <dependencies>
+
     <!-- Insights -->
     <dependency>
       <groupId>com.redhat.cloud.common</groupId>
       <artifactId>insights-notification-schemas-java</artifactId>
       <version>${insights-notification-schemas-java.version}</version>
     </dependency>
+
+    <!-- Quarkus -->
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-smallrye-reactive-messaging-kafka</artifactId>
+      <artifactId>quarkus-hibernate-validator</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-arc</artifactId>
+      <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy</artifactId>
+      <artifactId>quarkus-rest-client-reactive-jackson</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy-jackson</artifactId>
+      <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-security</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-fault-tolerance</artifactId>
     </dependency>
-
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-security</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
-    </dependency>
-
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-health</artifactId>
@@ -81,26 +77,21 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-rest-client-jackson</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-smallrye-opentracing</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-hibernate-validator</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.redhat.cloud.common</groupId>
-      <artifactId>clowder-quarkus-config-source</artifactId>
-      <version>${clowder-quarkus-config-source.version}</version>
+      <artifactId>quarkus-smallrye-reactive-messaging-kafka</artifactId>
     </dependency>
 
+    <!-- Quarkiverse -->
     <dependency>
       <groupId>io.quarkiverse.logging.cloudwatch</groupId>
       <artifactId>quarkus-logging-cloudwatch</artifactId>
       <version>6.6.0</version>
+    </dependency>
+
+    <!-- Clowder -->
+    <dependency>
+      <groupId>com.redhat.cloud.common</groupId>
+      <artifactId>clowder-quarkus-config-source</artifactId>
+      <version>${clowder-quarkus-config-source.version}</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/com/redhat/cloud/notifications/RestValidationClient.java
+++ b/src/main/java/com/redhat/cloud/notifications/RestValidationClient.java
@@ -4,11 +4,11 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Response;
 
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.jboss.resteasy.reactive.RestQuery;
 
 import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN;
 
@@ -21,6 +21,6 @@ public interface RestValidationClient {
     @Path("/baet")
     @Retry(maxRetries = 5)
     @Produces(TEXT_PLAIN)
-    Response validate(@QueryParam("bundle") String bundle, @QueryParam("application") String application, @QueryParam("eventType") String eventType);
+    Response validate(@RestQuery String bundle, @RestQuery String application, @RestQuery String eventType);
 
 }


### PR DESCRIPTION
The Quarkus team strongly encourages all projects to switch from resteasy classic to resteasy reactive because former may no longer be supported soon. Since the gateway is gaining attention these days, we'll do that now.