### PR TITLE
RHCLOUD-29010 Cache the B/A/ET validation results

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,10 @@
     <!-- Quarkus -->
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-cache</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-hibernate-validator</artifactId>
     </dependency>
     <dependency>

--- a/src/main/java/com/redhat/cloud/notifications/RestValidationClient.java
+++ b/src/main/java/com/redhat/cloud/notifications/RestValidationClient.java
@@ -1,5 +1,6 @@
 package com.redhat.cloud.notifications;
 
+import io.quarkus.cache.CacheResult;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -21,6 +22,7 @@ public interface RestValidationClient {
     @Path("/baet")
     @Retry(maxRetries = 5)
     @Produces(TEXT_PLAIN)
+    @CacheResult(cacheName = "baet-validation")
     Response validate(@RestQuery String bundle, @RestQuery String application, @RestQuery String eventType);
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -40,3 +40,5 @@ quarkus.log.cloudwatch.log-stream-name=notifications-gw
 quarkus.log.cloudwatch.level=INFO
 quarkus.log.cloudwatch.access-key-id=placeholder
 quarkus.log.cloudwatch.access-key-secret=placeholder
+
+quarkus.cache.caffeine.baet-validation.expire-after-write=PT10M


### PR DESCRIPTION
:warning: Based on #361 which has to be merged first.

For each message received by notifications-gw, an HTTP call to notifications-backend is made to validate the bundle / application / event-type triplet. Since the B/A/ET rarely change in the DB, we can cache the call result in notifications-gw for better performances.