### PR TITLE
Use ClowdApp template from stage in ephemeral

### DIFF
--- a/.rhcicd/pr_check.sh
+++ b/.rhcicd/pr_check.sh
@@ -5,6 +5,8 @@ set -exv
 # Clowder config
 export APP_NAME="notifications"
 export COMPONENT_NAME="notifications-gw"
+# The ClowdApp template from stage will be used in ephemeral, meaning that breaking template changes don't have to be deployed in production to fix the ephemeral deployment
+export REF_ENV="insights-stage"
 export IMAGE="quay.io/cloudservices/notifications-gw"
 
 # Bonfire init


### PR DESCRIPTION
Until now, whenever we introduced a breaking change in the ClowdApp template and it broke the deployment in ephemeral, we had to deploy that template up to production before ephemeral could be fixed.

Starting now, deploying the new template in stage will be enough to fix ephemeral.