### PR TITLE
Fix ClowderConfigSource warning at startup

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,7 +18,7 @@ quarkus.rest-client.rbac.url=https://ci.cloud.redhat.com
 quarkus.rest-client.rbac.connect-timeout=2000
 quarkus.rest-client.rbac.read-timeout=2000
 
-quarkus.rest-client.notifications-backend.url=${clowder.endpoints.notifications-backend-service:http://localhost:8085}
+quarkus.rest-client.notifications-backend.url=${clowder.endpoints.notifications-backend-service.url:http://localhost:8085}
 
 # OpenAPI path
 quarkus.smallrye-openapi.path=/openapi.json


### PR DESCRIPTION
Fixes
```
2023-10-25 11:47:32,501 WARN [com.red.clo.com.clo.con.ClowderConfigSource] (main) Endpoint 'notifications-backend-service' is using the old format. Please move to the new one: [Endpoint].[url|trust-store-path|trust-store-password|trust-store-type]
```