### PR TITLE
RHCLOUD-29031 Introduce quarkus-logging-sentry extension

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,8 @@
     <mockserver-netty-no-dependencies.version>5.15.0</mockserver-netty-no-dependencies.version>
     <insights-notification-schemas-java.version>0.20</insights-notification-schemas-java.version>
     <clowder-quarkus-config-source.version>2.0.0</clowder-quarkus-config-source.version>
+    <quarkus-logging-cloudwatch.version>6.6.0</quarkus-logging-cloudwatch.version>
+    <quarkus-logging-sentry.version>2.0.4</quarkus-logging-sentry.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -88,7 +90,12 @@
     <dependency>
       <groupId>io.quarkiverse.logging.cloudwatch</groupId>
       <artifactId>quarkus-logging-cloudwatch</artifactId>
-      <version>6.6.0</version>
+      <version>${quarkus-logging-cloudwatch.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkiverse.loggingsentry</groupId>
+      <artifactId>quarkus-logging-sentry</artifactId>
+      <version>${quarkus-logging-sentry.version}</version>
     </dependency>
 
     <!-- Clowder -->

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -41,4 +41,7 @@ quarkus.log.cloudwatch.level=INFO
 quarkus.log.cloudwatch.access-key-id=placeholder
 quarkus.log.cloudwatch.access-key-secret=placeholder
 
+quarkus.log.sentry=false
+quarkus.log.sentry.in-app-packages=com.redhat.cloud.notifications
+
 quarkus.cache.caffeine.baet-validation.expire-after-write=PT10M


### PR DESCRIPTION
The ClowdApp template already contained the settings for Sentry, but the Quarkus extension was missing :sweat_smile: 