### PR TITLE
Revert "Bump Quarkus to 3.5.0 (#371)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.version>3.5.0</quarkus.version>
+    <quarkus.version>3.4.3</quarkus.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <surefire-plugin.version>3.2.2</surefire-plugin.version>


### PR DESCRIPTION
Something's fishy with the pods memory. Let's see if 3.5.0 caused it.