### PR TITLE
Downgrade Quarkus to 3.4.3 (again)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.version>3.5.2</quarkus.version>
+    <quarkus.version>3.4.3</quarkus.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <surefire-plugin.version>3.2.2</surefire-plugin.version>


### PR DESCRIPTION
Quarkus 3.5.x is causing `OutOfMemoryError: Java heap space` at container startup so we'll stick with 3.4.3 for a while... There's a discussion in progress with the Quarkus team about this.