### PR TITLE
Downgrade Quarkus from 3.6.1 to 3.4.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.version>3.6.1</quarkus.version>
+    <quarkus.version>3.4.3</quarkus.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <surefire-plugin.version>3.2.2</surefire-plugin.version>


### PR DESCRIPTION
The memory issue is still there... we can't bump to something more recent than 3.4.3.