### PR TITLE
RHCLOUD-32001 | Improve dockerfile builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,7 @@
+# Ignore the internal configuration directories that might contain secrets.
+.docker
+.kube
+.podman
 
 !target/*-runner
 !target/*-runner.jar

--- a/.rhcicd/build_deploy.sh
+++ b/.rhcicd/build_deploy.sh
@@ -15,16 +15,15 @@ if [[ -z "$RH_REGISTRY_USER" || -z "$RH_REGISTRY_TOKEN" ]]; then
     exit 1
 fi
 
-# Set the job's build directory to something else other than the workspace, in
-# order to avoid leaks.
+# Create a temporary directory isolated from $WORKSPACE to store the Docker config and prevent leaking that config in the Docker image.
 readonly job_directory_path=$(mktemp --directory -p "${HOME}" -t "jenkins-${JOB_NAME}-${BUILD_NUMBER}.XXXXXX")
-echo "Temporary directory location for the job: ${job_directory_path}"
+echo "Temporary directory location for the Docker config: ${job_directory_path}"
 
 # job_directory_cleanup cleans forcefully and recursively removes the
 #                       specified directory path.
 # @param directory_path the path of the directory to remove.
 function job_directory_cleanup() {
-  echo "Cleaning up the temporary directory for the job: ${1}"
+  echo "Cleaning up the temporary directory for the Docker config: ${1}"
 
   rm --force --recursive "${1}"
 }


### PR DESCRIPTION
* By generating a unique temporary directory for our builds, we ensure
that we will not share the workspace with the rest of the builds of the
platform.

* By explicitly ignoring the internal directories we ensure that we will
not copy them to our images by accident.

## Jira ticket
[[RHCLOUD-32001]](https://issues.redhat.com/browse/RHCLOUD-32001)