### PR TITLE
RHCLOUD-30193 Trigger Konflux build on comment

### DIFF
--- a/.tekton/notifications-gw-pull-request.yaml
+++ b/.tekton/notifications-gw-pull-request.yaml
@@ -9,6 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "main"
+    pipelinesascode.tekton.dev/on-comment: "^/konflux$"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: notifications


### PR DESCRIPTION
This is an experiment with a tech preview feature from Konflux.

**After** this PR has been merged, if the feature works as expected, the build of a pull request will only happen in Konflux if we add the `/konflux` comment in the PR.

https://pipelinesascode.com/docs/guide/authoringprs/#matching-a-pipelinerun-on-a-regexp-in-a-comment