### PR TITLE
[RHCLOUD-37354] Add notifications backend outage resilient caches

### DIFF
--- a/.rhcicd/clowdapp.yaml
+++ b/.rhcicd/clowdapp.yaml
@@ -71,6 +71,8 @@ objects:
           value: ${NOTIFICATIONS_EMAILS_INTERNAL_ONLY_ENABLED}
         - name: NOTIFICATIONS_KAFKA_CALLBACK_TIMEOUT_SECONDS
           value: ${NOTIFICATIONS_KAFKA_CALLBACK_TIMEOUT_SECONDS}
+        - name: NOTIFICATIONS_BULK_CACHES_ENABLED
+          value: ${NOTIFICATIONS_BULK_CACHES_ENABLED}
         - name: QUARKUS_HTTP_PORT
           value: "8000"
         - name: QUARKUS_LOG_CATEGORY__COM_REDHAT_CLOUD_NOTIFICATIONS__LEVEL
@@ -137,3 +139,6 @@ parameters:
 - name: QUARKUS_LOG_LEVEL
   description: Log level for Quarkus
   value: INFO
+- name: NOTIFICATIONS_BULK_CACHES_ENABLED
+  description: Enable bulk baet and certificates caches (or not)
+  value: "false"

--- a/src/main/java/com/redhat/cloud/notifications/GwConfig.java
+++ b/src/main/java/com/redhat/cloud/notifications/GwConfig.java
@@ -1,6 +1,8 @@
 package com.redhat.cloud.notifications;
 
+import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import java.util.List;
@@ -14,11 +16,22 @@ public class GwConfig {
     @ConfigProperty(name = "notifications.allow-list.org-ids", defaultValue = "[]")
     List<String> allowListOrgIds;
 
+    @ConfigProperty(name = "notifications.bulk-caches.enabled", defaultValue = "false")
+    boolean bulkCachesEnabled;
+
     public boolean isAllowListEnabled() {
         return allowListEnabled;
     }
 
     public List<String> getAllowListOrgIds() {
         return allowListOrgIds;
+    }
+
+    public boolean isBulkCachesEnabled() { return bulkCachesEnabled; }
+
+    public void logConfiguration() {
+        Log.infof("notifications.bulk-caches.enabled = %s", bulkCachesEnabled);
+        Log.infof("notifications.allow-list.enabled = %s", allowListEnabled);
+        Log.infof("notifications.allow-list.org-ids = %s", allowListOrgIds);
     }
 }

--- a/src/main/java/com/redhat/cloud/notifications/GwResource.java
+++ b/src/main/java/com/redhat/cloud/notifications/GwResource.java
@@ -103,6 +103,8 @@ public class GwResource {
 
     List<SourceEnvironment> sourceEnvironments = new ArrayList<>();
 
+    // Store bundle, application and event types like
+    // Map<Bundle_name, Map<application_name, List<event_type_name>>
     Map<String, Map<String, List<String>>> mapBaet = new HashMap<>();
 
     public boolean init() {

--- a/src/main/java/com/redhat/cloud/notifications/GwResource.java
+++ b/src/main/java/com/redhat/cloud/notifications/GwResource.java
@@ -105,11 +105,9 @@ public class GwResource {
 
     Map<String, Map<String, List<String>>> mapBaet = new HashMap<>();
 
-    @PostConstruct
-    public void init() {
-        Log.info("Init caches");
-        refreshBaets();
-        refreshSourceEnvironment();
+
+    public boolean init() {
+        return refreshBaets() && refreshSourceEnvironment();
     }
 
     public GwResource(MeterRegistry registry) {

--- a/src/main/java/com/redhat/cloud/notifications/GwResource.java
+++ b/src/main/java/com/redhat/cloud/notifications/GwResource.java
@@ -105,7 +105,6 @@ public class GwResource {
 
     Map<String, Map<String, List<String>>> mapBaet = new HashMap<>();
 
-
     public boolean init() {
         return refreshBaets() && refreshSourceEnvironment();
     }
@@ -174,12 +173,8 @@ public class GwResource {
             }
         }
 
-
         if (gwConfig.isBulkCachesEnabled()) {
-            refreshBaets();
-            if (mapBaet.containsKey(ra.getBundle())
-                && mapBaet.get(ra.getBundle()).containsKey(ra.getApplication())
-                && mapBaet.get(ra.getBundle()).get(ra.getApplication()).contains(ra.getEventType())) {
+            if (checkEventType(ra.getBundle(), ra.getApplication(), ra.getEventType())) {
                 Log.debugf("Event type found for [bundle=%s, application=%s, eventType=%s]", ra.getBundle(), ra.getApplication(), ra.getEventType());
             } else {
                 String errorMessage = String.format("No event type found for [bundle=%s, application=%s, eventType=%s]", ra.getBundle(), ra.getApplication(), ra.getEventType());
@@ -312,6 +307,13 @@ public class GwResource {
             String responseEntity = buildResponseEntity(false, "Message delivery to Kafka failed, please try again later");
             return Response.status(SERVICE_UNAVAILABLE).entity(responseEntity).build();
         }
+    }
+
+    private boolean checkEventType(String bundle, String application, String eventType) {
+        refreshBaets();
+        return mapBaet.containsKey(bundle)
+            && mapBaet.get(bundle).containsKey(application)
+            && mapBaet.get(bundle).get(application).contains(eventType);
     }
 
     private static Message<String> buildMessageWithId(String payload, String sourceEnvironment, CompletableFuture<Void> callback) {

--- a/src/main/java/com/redhat/cloud/notifications/GwResource.java
+++ b/src/main/java/com/redhat/cloud/notifications/GwResource.java
@@ -12,9 +12,11 @@ import com.redhat.cloud.notifications.model.SourceEnvironment;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
+import io.quarkus.cache.CacheResult;
 import io.quarkus.logging.Log;
 import io.smallrye.reactive.messaging.kafka.api.OutgoingKafkaRecordMetadata;
 import io.vertx.core.json.JsonObject;
+import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.validation.Valid;
@@ -27,6 +29,8 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.SecurityContext;
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -97,6 +101,17 @@ public class GwResource {
     private final Counter receivedActions;
     private final Counter forwardedActions;
 
+    List<SourceEnvironment> sourceEnvironments = new ArrayList<>();
+
+    Map<String, Map<String, List<String>>> mapBaet = new HashMap<>();
+
+    @PostConstruct
+    public void init() {
+        Log.info("Init caches");
+        refreshBaets();
+        refreshSourceEnvironment();
+    }
+
     public GwResource(MeterRegistry registry) {
         receivedActions = registry.counter("notifications.gw.received");
         forwardedActions = registry.counter("notifications.gw.forwarded");
@@ -161,53 +176,72 @@ public class GwResource {
             }
         }
 
-        try (Response response = this.restValidationClient.validate(ra.getBundle(), ra.getApplication(), ra.getEventType())) {
-            // This try block is intentionally empty.
-        } catch (final WebApplicationException e) {
-            // Build a nice error message for the caller.
-            final Response response = e.getResponse();
-            String incomingErrorMessage;
-            // TODO The following try/catch block is a workaround for a Quarkus bug. Remove it ASAP!
-            try {
-                incomingErrorMessage = response.readEntity(String.class);
-            } catch (ConcurrentModificationException ex) {
-                incomingErrorMessage = "";
-                Log.error("Could not retrieve entity from notifications-backend response", ex);
-            }
-            // Determine which status code we will return to the gateway caller
-            // and log the error appropriately.
-            final String logMessage = "Unable to validate the provided rest action due to notifications-backend responding with an error. Received status code: %s, received error message: %s, received REST action in the gateway: %s";
-            final Status returningStatusCodeFromGW;
-            final String returningErrorMessageFromGW;
-            if (response.getStatus() == BAD_REQUEST.getStatusCode()) {
-                returningStatusCodeFromGW = BAD_REQUEST;
-                returningErrorMessageFromGW = incomingErrorMessage;
-                Log.debugf(logMessage, response.getStatus(), incomingErrorMessage, ra);
+
+        if (gwConfig.isBulkCachesEnabled()) {
+            refreshBaets();
+            if (mapBaet.containsKey(ra.getBundle())
+                && mapBaet.get(ra.getBundle()).containsKey(ra.getApplication())
+                && mapBaet.get(ra.getBundle()).get(ra.getApplication()).contains(ra.getEventType())) {
+                Log.debugf("Event type found for [bundle=%s, application=%s, eventType=%s]", ra.getBundle(), ra.getApplication(), ra.getEventType());
             } else {
-                returningStatusCodeFromGW = SERVICE_UNAVAILABLE;
-                returningErrorMessageFromGW = "Unable to validate the message, please try again later";
-                Log.errorf(logMessage, response.getStatus(), incomingErrorMessage, ra);
+                String errorMessage = String.format("No event type found for [bundle=%s, application=%s, eventType=%s]", ra.getBundle(), ra.getApplication(), ra.getEventType());
+                Log.debug(errorMessage);
+                return Response
+                    .status(BAD_REQUEST)
+                    .header(CONTENT_TYPE, APPLICATION_JSON)
+                    .entity(buildResponseEntity(false, errorMessage))
+                    .build();
             }
+        } else {
 
-            this.incrementFailuresCounter(returningStatusCodeFromGW);
+            try (Response response = this.restValidationClient.validate(ra.getBundle(), ra.getApplication(), ra.getEventType())) {
+                // This try block is intentionally empty.
+            } catch (final WebApplicationException e) {
+                // Build a nice error message for the caller.
+                final Response response = e.getResponse();
+                String incomingErrorMessage;
+                // TODO The following try/catch block is a workaround for a Quarkus bug. Remove it ASAP!
+                try {
+                    incomingErrorMessage = response.readEntity(String.class);
+                } catch (ConcurrentModificationException ex) {
+                    incomingErrorMessage = "";
+                    Log.error("Could not retrieve entity from notifications-backend response", ex);
+                }
+                // Determine which status code we will return to the gateway caller
+                // and log the error appropriately.
+                final String logMessage = "Unable to validate the provided rest action due to notifications-backend responding with an error. Received status code: %s, received error message: %s, received REST action in the gateway: %s";
+                final Status returningStatusCodeFromGW;
+                final String returningErrorMessageFromGW;
+                if (response.getStatus() == BAD_REQUEST.getStatusCode()) {
+                    returningStatusCodeFromGW = BAD_REQUEST;
+                    returningErrorMessageFromGW = incomingErrorMessage;
+                    Log.debugf(logMessage, response.getStatus(), incomingErrorMessage, ra);
+                } else {
+                    returningStatusCodeFromGW = SERVICE_UNAVAILABLE;
+                    returningErrorMessageFromGW = "Unable to validate the message, please try again later";
+                    Log.errorf(logMessage, response.getStatus(), incomingErrorMessage, ra);
+                }
 
-            // Notify the caller about the error.
-            return Response
-                .status(returningStatusCodeFromGW)
-                .header(CONTENT_TYPE, APPLICATION_JSON)
-                .entity(buildResponseEntity(false, returningErrorMessageFromGW))
-                .build();
-        } catch (final ProcessingException e) {
-            Log.errorf(e, "Unable to reach notifications-backend to validate the following payload: %s", ra);
+                this.incrementFailuresCounter(returningStatusCodeFromGW);
 
-            this.incrementFailuresCounter(SERVICE_UNAVAILABLE);
+                // Notify the caller about the error.
+                return Response
+                    .status(returningStatusCodeFromGW)
+                    .header(CONTENT_TYPE, APPLICATION_JSON)
+                    .entity(buildResponseEntity(false, returningErrorMessageFromGW))
+                    .build();
+            } catch (final ProcessingException e) {
+                Log.errorf(e, "Unable to reach notifications-backend to validate the following payload: %s", ra);
 
-            // Raised when the notifications-backend is unreachable.
-            return Response
-                .status(SERVICE_UNAVAILABLE)
-                .header(CONTENT_TYPE, APPLICATION_JSON)
-                .entity(buildResponseEntity(false, "Unable to validate the message, please try again later"))
-                .build();
+                this.incrementFailuresCounter(SERVICE_UNAVAILABLE);
+
+                // Raised when the notifications-backend is unreachable.
+                return Response
+                    .status(SERVICE_UNAVAILABLE)
+                    .header(CONTENT_TYPE, APPLICATION_JSON)
+                    .entity(buildResponseEntity(false, "Unable to validate the message, please try again later"))
+                    .build();
+            }
         }
 
         Action.ActionBuilder builder = new Action.ActionBuilder();
@@ -313,6 +347,23 @@ public class GwResource {
     }
 
     private Optional<SourceEnvironment> getSourceEnvironment(String bundle, String app, String authenticationData) {
+        if (gwConfig.isBulkCachesEnabled()) {
+            refreshSourceEnvironment();
+            Optional<SourceEnvironment> environment = sourceEnvironments.stream()
+                .filter(srcEnv -> bundle.equals(srcEnv.bundle) && app.equals(srcEnv.application) && authenticationData.equals(srcEnv.subjectDn))
+                .findFirst();
+
+            if (environment.isPresent()) {
+                Log.infof("Authentication validated, coming from source environment %s", environment.get().name);
+            } else {
+                Log.infof("Unable to validate authentication '%s' for bundle '%s' and application '%s'",
+                    authenticationData,
+                    bundle,
+                    app);
+            }
+            return environment;
+        }
+
         try {
             SourceEnvironment sourceEnvironment = restValidationClient.validateCertificate(bundle, app, authenticationData);
             Log.infof("Authentication validated, coming from source environment %s", sourceEnvironment.name);
@@ -324,6 +375,30 @@ public class GwResource {
                 app);
             return Optional.empty();
         }
+    }
+
+    @CacheResult(cacheName = "get-baets")
+    boolean refreshBaets() {
+        try {
+            mapBaet = restValidationClient.getBaets();
+            Log.infof("Baet map refreshed with %d bundles", mapBaet.size());
+            return true;
+        } catch (Exception ex) {
+            Log.error("Impossible to refresh baet map", ex);
+        }
+        return false;
+    }
+
+    @CacheResult(cacheName = "get-certificates")
+    boolean refreshSourceEnvironment() {
+        try {
+            sourceEnvironments = restValidationClient.getCertificates();
+            Log.infof("Source environments list refreshed with %d records", sourceEnvironments.size());
+            return true;
+        } catch (Exception ex) {
+            Log.error("Impossible to refresh source environments", ex);
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/com/redhat/cloud/notifications/NotificationsGwApp.java
+++ b/src/main/java/com/redhat/cloud/notifications/NotificationsGwApp.java
@@ -48,6 +48,9 @@ public class NotificationsGwApp {
     @Inject
     GwConfig gwConfig;
 
+    @Inject
+    GwResource gwResource;
+
     void init(@Observes StartupEvent ev) {
         initAccessLogFilter();
 
@@ -56,6 +59,9 @@ public class NotificationsGwApp {
         Log.infof(NOTIFICATIONS_URL_KEY + "=%s", ConfigProvider.getConfig().getValue(NOTIFICATIONS_URL_KEY, String.class));
 
         gwConfig.logConfiguration();
+        if (gwConfig.isBulkCachesEnabled() && false == gwResource.init()) {
+            throw new IllegalStateException("Baet and or Certificate caches didn't load properly");
+        }
     }
 
     private void initAccessLogFilter() {

--- a/src/main/java/com/redhat/cloud/notifications/NotificationsGwApp.java
+++ b/src/main/java/com/redhat/cloud/notifications/NotificationsGwApp.java
@@ -21,6 +21,7 @@ import io.quarkus.logging.Log;
 import io.quarkus.runtime.StartupEvent;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import java.io.BufferedReader;
@@ -44,12 +45,17 @@ public class NotificationsGwApp {
     @ConfigProperty(name = "quarkus.http.access-log.category")
     private String loggerName;
 
+    @Inject
+    GwConfig gwConfig;
+
     void init(@Observes StartupEvent ev) {
         initAccessLogFilter();
 
         Log.info(readGitProperties());
 
         Log.infof(NOTIFICATIONS_URL_KEY + "=%s", ConfigProvider.getConfig().getValue(NOTIFICATIONS_URL_KEY, String.class));
+
+        gwConfig.logConfiguration();
     }
 
     private void initAccessLogFilter() {

--- a/src/main/java/com/redhat/cloud/notifications/RestValidationClient.java
+++ b/src/main/java/com/redhat/cloud/notifications/RestValidationClient.java
@@ -41,14 +41,12 @@ public interface RestValidationClient {
     @GET
     @Path("/certificates")
     @Retry(maxRetries = 5)
-    @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
     List<SourceEnvironment> getCertificates();
 
     @GET
     @Path("/baet_list")
     @Retry(maxRetries = 5)
-    @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
     Map<String, Map<String, List<String>>> getBaets();
 }

--- a/src/main/java/com/redhat/cloud/notifications/RestValidationClient.java
+++ b/src/main/java/com/redhat/cloud/notifications/RestValidationClient.java
@@ -9,6 +9,8 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Response;
 
+import java.util.List;
+import java.util.Map;
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.jboss.resteasy.reactive.RestQuery;
@@ -36,4 +38,17 @@ public interface RestValidationClient {
     @CacheResult(cacheName = "certificate-validation")
     SourceEnvironment validateCertificate(@RestQuery String bundle, @RestQuery String application, @RestQuery String certificateSubjectDn);
 
+    @GET
+    @Path("/certificates")
+    @Retry(maxRetries = 5)
+    @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
+    List<SourceEnvironment> getCertificates();
+
+    @GET
+    @Path("/baet_list")
+    @Retry(maxRetries = 5)
+    @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
+    Map<String, Map<String, List<String>>> getBaets();
 }

--- a/src/main/java/com/redhat/cloud/notifications/model/SourceEnvironment.java
+++ b/src/main/java/com/redhat/cloud/notifications/model/SourceEnvironment.java
@@ -12,4 +12,10 @@ public class SourceEnvironment {
 
     @JsonProperty("source_environment")
     public String name;
+
+    public String subjectDn;
+
+    public String bundle;
+
+    public String application;
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -45,5 +45,3 @@ quarkus.cache.caffeine.certificate-validation.expire-after-write=PT10M
 quarkus.cache.caffeine.get-baets.expire-after-write=PT1H
 quarkus.cache.caffeine.get-certificates.expire-after-write=PT1H
 %test.notifications.restrict.access.by.orgid=false
-
-quarkus.log.category."io.quarkus.cache.runtime.caffeine.CaffeineCacheManagerBuilder".level=DEBUG

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -42,4 +42,8 @@ quarkus.log.sentry.in-app-packages=com.redhat.cloud.notifications
 
 quarkus.cache.caffeine.baet-validation.expire-after-write=PT10M
 quarkus.cache.caffeine.certificate-validation.expire-after-write=PT10M
+quarkus.cache.caffeine.get-baets.expire-after-write=PT1H
+quarkus.cache.caffeine.get-certificates.expire-after-write=PT1H
 %test.notifications.restrict.access.by.orgid=false
+
+quarkus.log.category."io.quarkus.cache.runtime.caffeine.CaffeineCacheManagerBuilder".level=DEBUG

--- a/src/test/java/com/redhat/cloud/notifications/GwResourceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/GwResourceTest.java
@@ -600,25 +600,25 @@ public class GwResourceTest {
 
         // baet list is not yet loaded
         testSimplePayload(uuid, bundle, application, eventType, HttpStatusCode.BAD_REQUEST);
-        verify(restValidationClient, times(0)).getBaets();
+        verify(restValidationClient, times(1)).getBaets();
         verify(gwResource, times(1)).refreshSourceEnvironment();
 
         // baet list has been loaded
         when(restValidationClient.getBaets()).thenReturn(Map.of(bundle, Map.of(application, List.of(eventType))));
         cacheBaet.invalidateAll().await().indefinitely();
         testSimplePayload(uuid, bundle, application, eventType, HttpStatusCode.OK);
-        verify(restValidationClient, times(1)).getBaets();
+        verify(restValidationClient, times(2)).getBaets();
 
         // Should use cached data
         testSimplePayload(uuid, bundle, application, eventType, HttpStatusCode.OK);
-        verify(restValidationClient, times(1)).getBaets();
+        verify(restValidationClient, times(2)).getBaets();
 
         // baet list failed to refresh
         cacheBaet.invalidateAll().await().indefinitely();
         when(restValidationClient.getBaets()).thenThrow(WebApplicationException.class);
         testSimplePayload(uuid, bundle, application, eventType, HttpStatusCode.OK);
-        // we expect 7 calls = 1 from previous exec + 1 attempts + 5 retries
-        verify(restValidationClient, times(7)).getBaets();
+        // we expect 7 calls = 2 from previous exec + 1 attempts + 5 retries
+        verify(restValidationClient, times(8)).getBaets();
     }
 
     @Test


### PR DESCRIPTION
The purpose of this PR is to allow usage of baet and certificates caches to get resilient regarding a notifications backend outage.