### PR TITLE
updating output image to reflect desired path

### DIFF
--- a/.tekton/notifications-gw-sc-pull-request.yaml
+++ b/.tekton/notifications-gw-sc-pull-request.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/hcc-fr-tenant/hcc-integrations-tenant/notifications-sc/notifications-gw-sc:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/hcc-integrations-tenant/notifications-sc/notifications-gw-sc:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile

--- a/.tekton/notifications-gw-sc-push.yaml
+++ b/.tekton/notifications-gw-sc-push.yaml
@@ -22,7 +22,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/hcc-fr-tenant/hcc-integrations-tenant/notifications-sc/notifications-gw-sc:{{revision}}
+    value: quay.io/redhat-user-workloads/hcc-integrations-tenant/notifications-sc/notifications-gw-sc:{{revision}}
   - name: dockerfile
     value: ./src/main/docker/Dockerfile-build.jvm
   - name: path-context


### PR DESCRIPTION
## Summary by Sourcery

Update the output-image paths in Tekton pipeline configurations to point to the correct repository

Enhancements:
- Remove obsolete "hcc-fr-tenant" segment from output-image value in pull-request pipeline
- Remove obsolete "hcc-fr-tenant" segment from output-image value in push pipeline