### PR TITLE
chore: configure renovate to only run on main branch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>konflux-ci/mintmaker//config/renovate/renovate.json"],
   "baseBranches": ["main"],
   "tekton": {
     "schedule": ["at any time"]


### PR DESCRIPTION
Currently, mintmaker will try to update all onboarded components but this is unnecessary for SC branches and just clutters the repo PR list. Only allowing renovate to run on main/master should help.

## Summary by Sourcery

Chores:
- Add renovate.json to restrict Renovate to only run on main/master branches