### PR TITLE
[RHCLOUD-41536] add severity to RestAction

### DIFF
--- a/src/main/java/com/redhat/cloud/notifications/GwResource.java
+++ b/src/main/java/com/redhat/cloud/notifications/GwResource.java
@@ -284,6 +284,7 @@ public class GwResource {
         builder.withApplication(ra.application);
         builder.withBundle(ra.bundle);
         builder.withAccountId(ra.accountId);
+        builder.withSeverity(ra.severity);
         builder.withContext(contextBuilder.build());
         builder.withOrgId(ra.orgId);
         builder.withId(ra.id);

--- a/src/main/java/com/redhat/cloud/notifications/RestAction.java
+++ b/src/main/java/com/redhat/cloud/notifications/RestAction.java
@@ -70,6 +70,9 @@ public class RestAction {
     @JsonProperty("org_id")
     public String orgId;
 
+    @JsonProperty("severity")
+    public String severity;
+
     @JsonProperty("recipients_authorization_criterion")
     public RecipientsAuthorizationCriterion recipientsAuthorizationCriterion;
 
@@ -137,6 +140,14 @@ public class RestAction {
         this.orgId = orgId;
     }
 
+    public String getSeverity() {
+        return severity;
+    }
+
+    public void setSeverity(String severity) {
+        this.severity = severity;
+    }
+
     public List<RestEvent> getEvents() {
         return events;
     }
@@ -180,6 +191,7 @@ public class RestAction {
         json.put("timestamp", this.timestamp);
         json.put("accountId", this.accountId);
         json.put("orgId", this.orgId);
+        json.put("severity", this.severity);
         json.put("events", this.events);
         json.put("context", this.context);
         json.put("recipients", this.recipients);

--- a/src/main/java/com/redhat/cloud/notifications/SamplesResource.java
+++ b/src/main/java/com/redhat/cloud/notifications/SamplesResource.java
@@ -33,6 +33,7 @@ public class SamplesResource {
         a.setBundle("my-bundle");
         a.setAccountId("123");
         a.setOrgId("234567");
+        a.setSeverity("Important");
         a.setApplication("my-app");
         a.setEventType("a_type");
         List<RestEvent> events = new ArrayList<RestEvent>();

--- a/src/test/java/com/redhat/cloud/notifications/GwResourceTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/GwResourceTest.java
@@ -246,6 +246,7 @@ public class GwResourceTest {
         ra.setEvents(events);
         ra.setTimestamp("2020-12-18T17:04:04.417921");
         ra.setContext(new HashMap<>());
+        ra.setSeverity("Critical");
 
         List<RestRecipient> recipients = new ArrayList<>();
         RestRecipient recipient = new RestRecipient();
@@ -293,6 +294,7 @@ public class GwResourceTest {
         assertEquals(ra.accountId, am.get("account_id"));
         assertEquals(ra.orgId, am.get("org_id"));
         assertEquals(ra.id.toString(), am.get("id"));
+        assertEquals(ra.severity, am.get("severity"));
         List<Map<String, Object>> eventList = (List<Map<String, Object>>) am.get("events");
         assertEquals(1, eventList.size());
 

--- a/src/test/java/com/redhat/cloud/notifications/RestActionValidationTest.java
+++ b/src/test/java/com/redhat/cloud/notifications/RestActionValidationTest.java
@@ -54,6 +54,7 @@ public class RestActionValidationTest {
         a.setEvents(events);
         a.setTimestamp("2020-12-18T17:04:04.417921");
         a.setContext(new HashMap());
+        a.setSeverity("Important");
 
         Set<ConstraintViolation<RestAction>> violations = validator.validate(a);
         assertEquals(0,violations.size(), violations.toString());


### PR DESCRIPTION
## Jira ticket

https://issues.redhat.com/browse/RHCLOUD-41536

## Description

> [!WARNING]
> ~~Merge after https://github.com/RedHatInsights/insights-schemas-java/pull/167 and a new release of `insights-notifications-schema` is released. The version needs to be bumped in pom.xml as part of this PR.~~
> 
> This has been merged.

Add support for forwarding the `severity` field from an external payload to the backend.

## Compatibility

Supports forwarding an additional payload field, if present.

## Testing

Added test cases for `GwResource` and `RestAction`.

## Summary by Sourcery

Add support for a severity field in RestAction and ensure it is forwarded to the backend

Enhancements:
- Add severity property to RestAction model, including JSON mapping, getters/setters, and toString serialization
- Forward the severity field through GwResource builder and include it in SamplesResource responses

Tests:
- Add test cases in RestActionValidationTest and GwResourceTest to validate severity field presence and forwarding