### PR TITLE
Add AI agent readiness files and domain-specific guidelines

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+# See https://docs.coderabbit.ai/reference/configuration for all fields and default values
+knowledge_base:
+  code_guidelines:
+    filePatterns:
+      - "docs/*-guidelines.md"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# AGENTS.md
+
+## Docs Index
+
+Domain-specific guidelines for implementation and review agents:
+
+- [Security](docs/security-guidelines.md) — Authentication (x-rh-identity), authorization (allow-list), input validation, secrets management
+- [Performance](docs/performance-guidelines.md) — Caching strategies, thread safety, Kafka producer patterns, metrics
+- [Error Handling](docs/error-handling-guidelines.md) — Response format, HTTP status codes, REST client errors, Kafka delivery errors, logging
+- [API Contracts](docs/api-contracts-guidelines.md) — REST endpoints, OpenAPI, request/response models, bean validation, REST client conventions
+- [Testing](docs/testing-guidelines.md) — Test stack, integration vs unit tests, lifecycle management, Kafka/cache testing
+- [Integration](docs/integration-guidelines.md) — Kafka messaging, REST client integration, message serialization, event-driven architecture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/docs/api-contracts-guidelines.md
+++ b/docs/api-contracts-guidelines.md
@@ -1,0 +1,97 @@
+# API Contracts Guidelines
+
+## Framework and Stack
+
+- **Runtime**: Quarkus (RESTEasy Reactive) with Jackson serialization (`quarkus-rest-jackson`, `quarkus-rest-client-jackson`).
+- **Validation**: `quarkus-hibernate-validator` (Jakarta Bean Validation).
+- **OpenAPI**: SmallRye OpenAPI (`quarkus-smallrye-openapi`), served at `/openapi.json`.
+- **OpenAPI operation IDs**: Generated via `CLASS_METHOD` strategy (`mp.openapi.extensions.smallrye.operationIdStrategy=CLASS_METHOD`).
+
+## Path Conventions
+
+- Resource classes use `@Path` at the class level. The primary resource is mounted at `/notifications`.
+- In production, 3scale exposes the path `/api/notifications-gw/notifications`. The `IncomingRequestInterceptor` (a `@PreMatching` `ContainerRequestFilter`) rewrites that path to `/notifications` for ephemeral environments where 3scale is absent.
+- Non-application endpoints (health, metrics, OpenAPI) are served from the root (`/`) via `quarkus.http.non-application-root-path=/`. Do not change this -- tests in `NonApplicationRootPathTest` verify `/health`, `/metrics`, and `/openapi.json` are accessible without a `/q/` prefix.
+
+## Content Negotiation
+
+- All resource classes declare both `@Consumes(APPLICATION_JSON)` and `@Produces(APPLICATION_JSON)` at the class level.
+- REST clients (`RestValidationClient`, `RestInternalClient`) also annotate each method with `@Produces` and optionally `@Consumes` to be explicit about the expected media types. The `/internal/validation/baet` endpoint is an exception that produces `TEXT_PLAIN`.
+
+## Request/Response Model Conventions
+
+### JSON Field Naming
+
+- Models use **snake_case** for JSON field names, achieved via `@JsonProperty` annotations on individual fields (e.g., `@JsonProperty("event_type")`, `@JsonProperty("org_id")`, `@JsonProperty("account_id")`).
+- The `SourceEnvironment` model uses `@JsonNaming(SnakeCaseStrategy.class)` as a class-level alternative. Both approaches coexist; prefer `@JsonProperty` on gateway-facing models for explicitness.
+- Always apply `@JsonIgnoreProperties(ignoreUnknown = true)` on models deserialized from external services to prevent breakage when upstream adds fields.
+
+### Model Structure
+
+- Request/response models are plain POJOs with public fields and getter/setter pairs (not records). Fields that are optional omit `@NotNull`.
+- The `RestAction` model is the primary inbound payload. It references `RestEvent` (list), `RestRecipient` (optional list), and a free-form `Map<String, Object> context`.
+- The `toString()` on `RestAction` uses `JsonObject.encode()` for structured logging; follow this pattern when adding loggable models.
+
+### Standard Response Envelope
+
+All responses from the `forward` endpoint use a JSON envelope built by `buildResponseEntity`:
+```json
+{"result": "success"}
+{"result": "error", "details": "description of the problem"}
+```
+Do not return raw strings or alternative shapes from gateway endpoints.
+
+## Bean Validation Rules
+
+### Naming Identifiers
+
+`bundle`, `application`, and `eventType` fields must match `[a-z][a-z_0-9-]*` -- lowercase, starting with a letter, allowing underscores and hyphens. This is enforced with `@Pattern` and is also checked by `@NotNull @NotEmpty`.
+
+### Custom Validators
+
+- The `@ISO8601Timestamp` annotation is a custom constraint backed by `TimestampValidator`. It validates that the `timestamp` field parses as `ISO_LOCAL_DATE_TIME` (e.g., `2020-12-18T17:04:04.417921`). No timezone offset is accepted.
+- Email addresses in `RestRecipient.emails` are validated with `@Pattern(regexp = "^\\S+@\\S+\\.\\S+$")` applied at the list element level: `List<@Pattern(...) String>`.
+
+### Cascading Validation
+
+- The `forward` method parameter uses `@NotNull @Valid RestAction ra` to trigger validation on the body.
+- Inside `RestAction`, the `recipients` field is annotated `@Valid` to cascade validation into each `RestRecipient`.
+
+### Positive-String Pattern
+
+`accountId` and `orgId` are typed as `String` (to preserve leading zeros) but annotated `@Positive` to enforce they contain only positive numeric values.
+
+## Authentication
+
+- Authentication is handled by `RHIdAuthMechanism`, which reads the `x-rh-identity` header (Base64-encoded JSON).
+- The identity JSON is deserialized into `XRhIdentity` -> `Identity` using Jackson polymorphic deserialization keyed on the `type` field (`X509`, `Associate`, `ServiceAccount`).
+- The principal extracted (`RhIdPrincipal`) carries `subject` and `type`. The `type` determines source-environment validation behavior in `GwResource`.
+
+## Request Interceptor
+
+- `IncomingRequestInterceptor` is a `@Provider @PreMatching` filter. It performs path rewriting only, no authentication or header manipulation.
+- It includes an anti-injection pattern (`[\n|\r|\t]`) to sanitize URIs before trace-level logging, preventing log forging.
+
+## REST Client Conventions
+
+- REST clients are MicroProfile REST Client interfaces annotated with `@RegisterRestClient(configKey = "...")`.
+- They must be `@ApplicationScoped` to support mocking in tests via `@InjectMock @RestClient`.
+- Fault tolerance: all REST client methods use `@Retry(maxRetries = 5)`.
+- Caching: use Quarkus `@CacheResult(cacheName = "...")` on client methods or on wrapper methods in the resource. Cache TTLs are configured in `application.properties` under `quarkus.cache.caffeine.<name>.expire-after-write`.
+- Query parameters use `@RestQuery` (RESTEasy Reactive), not `@QueryParam`. Path parameters use `@RestPath`, not `@PathParam` (in client interfaces).
+
+## OpenAPI Annotations
+
+- Use `@Operation(summary = "...")` on endpoint methods.
+- Document all response codes with `@APIResponses` / `@APIResponse`, including `401` (even without a description, for completeness).
+- Do not add OpenAPI annotations to REST client interfaces.
+
+## Error Handling Strategy
+
+- Validation errors from the backend returning HTTP 400 are forwarded to the caller as 400 with the backend's error message.
+- All other backend errors (5xx, network failures) are returned as 503 with a generic "please try again later" message. Never expose internal error details for non-400 errors.
+- Backend errors (non-400) and Kafka delivery failures increment a Micrometer counter (`notifications.gw.failed.requests`) tagged with the returned `status_code` (503). Client errors (400, 403) do not increment this counter.
+
+## Internal Email Restriction
+
+When `notifications.emails.internal-only.enabled` is `true` (the default), all email addresses in `recipients.emails` must end with `@redhat.com`. Non-matching addresses cause a 400 response listing the offending addresses. Any new endpoint accepting email recipients must enforce this same rule.

--- a/docs/error-handling-guidelines.md
+++ b/docs/error-handling-guidelines.md
@@ -1,0 +1,115 @@
+# Error Handling Guidelines
+
+## 1. Response Format
+
+All error responses MUST use the standard JSON envelope built by `GwResource.buildResponseEntity()`:
+
+```json
+{"result": "error", "details": "<human-readable message>"}
+```
+
+Success responses use the same shape with `"result": "success"` and no `details` field. Always set the `Content-Type: application/json` header explicitly on error responses.
+
+## 2. HTTP Status Code Selection
+
+Use exactly three error status codes, chosen by origin of the failure:
+
+| Status | When to use |
+|--------|-------------|
+| **400 Bad Request** | Validation failures originating from the caller's payload, OR when the notifications-backend itself returned 400. Propagate the backend's error message directly. |
+| **403 Forbidden** | The allow-list rejected the request (staging source + unlisted org ID). |
+| **503 Service Unavailable** | Any non-400 error from the notifications-backend, any `ProcessingException` (backend unreachable), any Kafka delivery failure (nack or timeout). Always use a generic message -- never expose internal details. |
+
+Do NOT use 404, 500, or other status codes from `GwResource`. For non-400 backend errors, always map to 503.
+
+## 3. Validation
+
+### 3.1 Jakarta Bean Validation (declarative)
+
+Input validation is declarative on the `RestAction` and `RestRecipient` model classes. The framework returns 400 automatically for constraint violations before the resource method runs.
+
+- Field-name patterns: `@Pattern(regexp = "[a-z][a-z_0-9-]*")` on `bundle`, `application`, `eventType`.
+- Nullability: `@NotNull @NotEmpty` on required string fields.
+- Numeric strings: `@Positive` on `accountId` and `orgId` (stored as `String` to allow leading zeros).
+- Email format: `@Pattern` on individual list elements in `RestRecipient.emails`.
+- Timestamp: Custom `@ISO8601Timestamp` annotation backed by `TimestampValidator`, which parses with `DateTimeFormatter.ISO_LOCAL_DATE_TIME`.
+- Use `@Valid` on nested objects (e.g., `RestAction.recipients`) to cascade validation.
+
+### 3.2 Business validation (imperative, in GwResource.forward)
+
+After bean validation passes, `forward()` performs additional checks in this order:
+
+1. **Allow-list check** -- staged source environments must target a whitelisted org ID.
+2. **Internal-email-only check** -- when `internalEmailsOnly` is enabled, all emails must end with `@redhat.com`.
+3. **Event type validation** -- either via the bulk-cache map lookup or a REST call to notifications-backend.
+
+Each check returns a `Response` directly on failure; it does NOT throw an exception.
+
+## 4. REST Client Error Handling
+
+### 4.1 Fault tolerance on REST clients
+
+All methods on `RestValidationClient` and `RestInternalClient` are annotated with `@Retry(maxRetries = 5)` via MicroProfile Fault Tolerance. Do not add retry logic in the calling code; the client interface handles it.
+
+### 4.2 Catching REST client exceptions in GwResource
+
+When calling `restValidationClient.validate()` without bulk caches, catch two exception types in this order:
+
+1. **`WebApplicationException`** -- the backend responded with an HTTP error. Extract the response status and entity. If status is 400, relay the backend's message with 400. Otherwise, return 503 with a generic message.
+2. **`ProcessingException`** -- the backend was unreachable. Return 503 with a generic message.
+
+When reading the response entity from a `WebApplicationException`, wrap the call in a secondary try/catch for `ConcurrentModificationException` (Quarkus bug workaround).
+
+### 4.3 Swallowed exceptions in cache-refresh and certificate-validation paths
+
+`refreshBaets()`, `refreshSourceEnvironment()`, and `getSourceEnvironment()` catch `Exception` broadly, log the error, and return a fallback value (`false`, `Optional.empty()`, or stale cached data). This is intentional -- these failures must not block the main request flow.
+
+## 5. Kafka Delivery Errors
+
+The `emitter.send(message)` call uses a `CompletableFuture` callback pattern:
+
+- `callback.get(callbackTimeout, TimeUnit.SECONDS)` blocks until Kafka acks or nacks.
+- Any `Throwable` (including `ExecutionException` from nack and `TimeoutException`) is caught, logged at ERROR, and mapped to 503.
+- The timeout is configurable via `notifications.kafka-callback-timeout-seconds` (default: 60).
+
+Always catch `Throwable` (not `Exception`) for the Kafka path, matching the existing convention.
+
+## 6. Logging Conventions
+
+Use `io.quarkus.logging.Log` (static import) exclusively. Do NOT use `java.util.logging`, SLF4J, or `System.err` in production code.
+
+### Log levels by error category
+
+| Level | Usage |
+|-------|-------|
+| `Log.errorf` | Backend returned non-400 error, Kafka delivery failed, cache refresh failed. Always include the exception object. |
+| `Log.warnf` | Allow-list rejection, identity header deserialization failure. |
+| `Log.debugf` | Backend returned 400 (caller's fault), event type not found in cache. |
+| `Log.infof` | Successful operations -- cache refreshes, authentication validation results. |
+
+### Log message conventions
+
+- Use `f`-suffix methods (`Log.errorf`, `Log.warnf`, `Log.debugf`) with `%s`/`%d` format specifiers -- not string concatenation.
+- Include structured context in brackets: `[bundle=%s, application=%s, eventType=%s]`.
+- For validation logging, include the full `RestAction` via its `toString()` (which outputs JSON).
+- When logging with an exception using `errorf`: pass it as the first argument: `Log.errorf(exception, "message %s", arg)`.
+- When logging with an exception using `error`: pass it as the second argument: `Log.error("message", exception)`.
+
+## 7. Metrics for Errors
+
+Increment the `notifications.gw.failed.requests` counter (via `incrementFailuresCounter()`) for error responses from REST client failures and Kafka delivery failures. This includes both 400 errors from backend validation and 503 errors. Tag with `status_code`. The counter is NOT incremented for 400 errors from local validation (bulk cache mode, internal email check) or 403 errors from allow-list rejection.
+
+## 8. Security: Log Injection Prevention
+
+The `IncomingRequestInterceptor` sanitizes URI strings in log output using `ANTI_INJECTION_PATTERN` which strips `\n`, `\r`, and `\t`. Apply the same pattern when logging any externally-sourced string at TRACE level.
+
+## 9. Startup Failure
+
+When `bulkCachesEnabled` is true and cache initialization fails, `NotificationsGwApp.init()` throws `IllegalStateException` to prevent the application from starting in a degraded state. This is a fail-fast pattern -- do not catch this exception.
+
+## 10. Test Conventions for Error Cases
+
+- Mock `RestValidationClient` with `@InjectMock @RestClient` and throw `WebApplicationException` to simulate backend errors.
+- Test all non-400 backend status codes (500, 501, 502, 503, 504, 507) and assert they all map to 503 from the gateway.
+- Assert both the HTTP status code and the full JSON response body (`result` + `details` fields).
+- Use `InMemoryConnector` / `InMemorySink` for Kafka, avoiding real broker dependencies.

--- a/docs/integration-guidelines.md
+++ b/docs/integration-guidelines.md
@@ -1,0 +1,132 @@
+# Integration Guidelines
+
+## Architecture Overview
+
+notifications-gw is a Quarkus gateway that receives REST notification payloads, validates them against notifications-backend, and forwards them to Kafka for downstream processing. It has a single core flow: `POST /notifications/` -> validate -> serialize -> Kafka produce.
+
+## Kafka Messaging
+
+### Topic and Channel
+
+- The sole outgoing Kafka channel is named `egress`, mapped to topic `platform.notifications.ingress`.
+- Reference the channel constant `GwResource.EGRESS_CHANNEL` ("egress") rather than hardcoding the string.
+- The Clowdapp declares this topic with 3 partitions and 3 replicas.
+
+### Producer Pattern
+
+- Use `@Channel(EGRESS_CHANNEL) Emitter<String>` for sending messages. The payload is always a `String` (JSON-encoded Action).
+- Serialization uses `StringSerializer` for both key and value -- never use `JsonObjectSerializer`.
+- Every message must carry a `rh-message-id` Kafka header set to a random UUID v4 encoded as UTF-8 bytes.
+- Optionally attach a `rh-source-environment` header when the sender is identified as originating from a non-production source environment.
+- Build messages via `OutgoingKafkaRecordMetadata` to attach headers:
+
+```java
+Headers headers = new RecordHeaders().add(MESSAGE_ID_HEADER, messageId);
+OutgoingKafkaRecordMetadata<String> metadata = OutgoingKafkaRecordMetadata.<String>builder()
+        .withHeaders(headers).build();
+Message.of(payload).addMetadata(metadata).withAck(...).withNack(...);
+```
+
+### Ack/Nack Callback
+
+- Every Kafka send must use a `CompletableFuture<Void>` callback wired through `withAck`/`withNack` on the `Message`.
+- Block on `callback.get(callbackTimeout, TimeUnit.SECONDS)` -- the timeout defaults to 60s and is configurable via `notifications.kafka-callback-timeout-seconds`.
+- On any callback failure (nack or timeout), return HTTP 503 with `{"result":"error","details":"..."}`.
+
+## Message Serialization
+
+- Incoming REST payloads use `RestAction` (snake_case JSON via `@JsonProperty`). Outgoing Kafka payloads use the `Action` type from the `insights-notification-schemas-java` library.
+- Convert `RestAction` -> `Action` using the builder pattern (`Action.ActionBuilder`), then serialize with `Parser.encode(action)`.
+- Never send `RestAction` directly to Kafka. The `Action` schema is the contract with downstream consumers.
+- Timestamps must be ISO 8601 local date-time format (e.g. `2020-12-18T17:04:04.417921`), validated by the custom `@ISO8601Timestamp` annotation and `TimestampValidator`.
+
+## REST Action Payload Validation
+
+### Field Constraints
+
+- `bundle`, `application`, `event_type`: required, must match `[a-z][a-z_0-9-]*` (lowercase, starts with letter).
+- `org_id`: required, must be a positive number (String type to allow leading zeros).
+- `account_id`: optional, positive number when present.
+- `events`: required, each event must have a non-empty `payload` map.
+- `recipients.emails`: validated against `^\S+@\S+\.\S+$`. When `notifications.emails.internal-only.enabled` is true, only `@redhat.com` addresses are allowed.
+
+### Bundle/Application/EventType Validation
+
+Two modes controlled by `notifications.bulk-caches.enabled`:
+- **Disabled (default)**: Calls `RestValidationClient.validate()` per request against notifications-backend (`/internal/validation/baet`).
+- **Enabled**: Loads the full bundle/application/event-type map via `RestValidationClient.getBaets()` into an in-memory cache (1-hour TTL) and validates locally.
+
+## REST Client Integration
+
+### Client Declaration
+
+- REST clients use `@RegisterRestClient(configKey = "notifications-backend")` and must be `@ApplicationScoped` (required for test mocking).
+- Base URL configured via `quarkus.rest-client.notifications-backend.url`, which resolves from Clowder in deployed environments.
+
+### Fault Tolerance
+
+- All REST client methods must use `@Retry(maxRetries = 5)` from MicroProfile Fault Tolerance.
+- Validation responses from backend: HTTP 400 is forwarded as 400 to caller; all other error codes are mapped to HTTP 503.
+- `ProcessingException` (backend unreachable) also maps to HTTP 503.
+
+### Caching
+
+- Per-request validation results are cached with Caffeine: `baet-validation` and `certificate-validation` caches (10-minute TTL).
+- Bulk caches (`get-baets`, `get-certificates`) have a 1-hour TTL.
+- Cache names are referenced via `@CacheResult(cacheName = "...")` on the client methods or resource methods.
+
+## Authentication
+
+- All requests require a Base64-encoded `x-rh-identity` header containing a JSON identity object.
+- Supported identity types: `X509` (with `subject_dn` and `issuer_dn`), `ServiceAccount`, and `Associate`.
+- The `RHIdAuthMechanism` decodes the header and creates an `RhIdPrincipal` with `subject` and `type`.
+- Source environment lookup (stage vs. prod) only applies to `X509` and `ServiceAccount` identity types.
+
+## Allow List (Stage Environment Gating)
+
+- When `notifications.allow-list.enabled=true`, messages from `stage` source environments are rejected unless the `org_id` appears in `notifications.allow-list.org-ids`.
+- Rejected messages return HTTP 403.
+
+## Response Format
+
+All responses from the gateway use a consistent JSON structure:
+
+```json
+{"result": "success|error", "details": "optional error message"}
+```
+
+Build responses using `JsonObject` from Vert.x -- do not use Jackson for gateway responses.
+
+## Integration Testing Conventions
+
+### Test Infrastructure
+
+- Tests use `@QuarkusTest` with `@QuarkusTestResource(TestLifecycleManager.class)`.
+- `TestLifecycleManager` starts MockServer for backend simulation and switches Kafka to in-memory via `InMemoryConnector.switchOutgoingChannelsToInMemory(EGRESS_CHANNEL)`.
+
+### Kafka Message Verification
+
+- Access sent messages via `InMemorySink<String>`: inject `@Any InMemoryConnector`, then `connector.sink(EGRESS_CHANNEL)`.
+- Wait for messages with Awaitility: `await().atMost(Duration.ofSeconds(10L)).until(() -> sink.received().size() > 0)`.
+- Clear the sink in `@BeforeEach` to isolate tests.
+- Verify Kafka headers via `message.getMetadata(KafkaMessageMetadata.class)`.
+
+### Request Path Testing
+
+Test both `/notifications/` (direct) and `/api/notifications-gw/notifications` (3scale path used in production/stage). The `IncomingRequestInterceptor` rewrites the latter to the former in ephemeral environments where 3scale is absent.
+
+## Metrics
+
+- `notifications.gw.received`: counter incremented on every incoming request.
+- `notifications.gw.forwarded`: counter incremented on successful Kafka send.
+- `notifications.gw.failed.requests`: counter with `status_code` tag, incremented on validation or delivery failures.
+
+## Configuration Reference
+
+| Property | Default | Purpose |
+|---|---|---|
+| `notifications.kafka-callback-timeout-seconds` | 60 | Kafka ack/nack wait timeout |
+| `notifications.emails.internal-only.enabled` | true | Restrict recipient emails to @redhat.com |
+| `notifications.allow-list.enabled` | false | Enable org ID allowlist for stage sources |
+| `notifications.allow-list.org-ids` | [] | Allowed org IDs for stage sources |
+| `notifications.bulk-caches.enabled` | false | Use bulk in-memory caches instead of per-request validation |

--- a/docs/performance-guidelines.md
+++ b/docs/performance-guidelines.md
@@ -1,0 +1,119 @@
+# Performance Guidelines
+
+## Architecture Overview
+
+This is a Quarkus-based gateway that receives REST notifications, validates them against a backend service, and forwards them to Kafka. The critical path is: HTTP request -> validation -> Kafka produce -> synchronous ack wait.
+
+## Caching
+
+### Two Caching Strategies (Controlled by Feature Flag)
+
+The `notifications.bulk-caches.enabled` flag switches between two validation modes:
+
+1. **Per-request validation (default, flag=false):** Each request calls `RestValidationClient.validate()` which has its own `@CacheResult(cacheName = "baet-validation")` with 10-minute TTL. Certificate validation uses `@CacheResult(cacheName = "certificate-validation")` with 10-minute TTL. These caches are keyed by method parameters (bundle, application, eventType / certificateSubjectDn).
+
+2. **Bulk cache mode (flag=true):** On startup and periodically, the full BAET map and certificate list are fetched via `refreshBaets()` and `refreshSourceEnvironment()`. These use `@CacheResult(cacheName = "get-baets")` and `@CacheResult(cacheName = "get-certificates")` with 1-hour TTL. Lookups then happen in-memory against `mapBaet` and `sourceEnvironments` fields.
+
+### Cache Configuration Reference
+
+All cache durations live in `application.properties`:
+```properties
+quarkus.cache.caffeine.baet-validation.expire-after-write=PT10M
+quarkus.cache.caffeine.certificate-validation.expire-after-write=PT10M
+quarkus.cache.caffeine.get-baets.expire-after-write=PT1H
+quarkus.cache.caffeine.get-certificates.expire-after-write=PT1H
+```
+
+### Rules
+
+- Never add a new cache without a corresponding `expire-after-write` entry in `application.properties`.
+- Cache names in `@CacheResult` annotations must exactly match the Caffeine config keys.
+- When testing cached methods, inject the `Cache` by name and call `invalidateAll().await().indefinitely()` in setup to ensure test isolation.
+- The `@CacheResult` on `refreshBaets()` and `refreshSourceEnvironment()` means the method body only executes once per TTL window regardless of how many requests arrive. The boolean return value is what gets cached, but the side effect (populating `mapBaet` / `sourceEnvironments`) is the real purpose.
+
+## Thread Safety
+
+### Known Concerns
+
+- `GwResource.mapBaet` and `GwResource.sourceEnvironments` are mutable instance fields on an `@ApplicationScoped` bean. They are reassigned (not mutated) from `refreshBaets()` and `refreshSourceEnvironment()`, which are guarded by `@CacheResult` TTL. The fields are not `volatile` and have no synchronization. This is acceptable in practice because Caffeine's cache provides a happens-before relationship for the thread that triggers refresh, and stale reads from other threads are tolerable (the old data remains valid).
+- Do not switch these fields to concurrent mutation patterns (e.g., adding/removing entries). If you need to update them incrementally, introduce proper synchronization or use `ConcurrentHashMap`.
+- The `ConcurrentModificationException` catch in the `forward()` method (around `response.readEntity()`) is a documented Quarkus bug workaround. Do not remove it without verifying the upstream fix.
+
+## Kafka Producer
+
+### Synchronous Callback Pattern
+
+The gateway uses a `CompletableFuture` callback attached to each Kafka message to convert async Kafka production into a synchronous HTTP response:
+
+```java
+CompletableFuture<Void> callback = new CompletableFuture<>();
+Message<String> message = buildMessageWithId(serializedAction, sourceEnvironment, callback);
+emitter.send(message);
+callback.get(callbackTimeout, TimeUnit.SECONDS);
+```
+
+### Rules
+
+- The `callbackTimeout` defaults to 60 seconds (`notifications.kafka-callback-timeout-seconds`). This directly affects maximum HTTP response latency. Do not increase it without load testing.
+- Every message gets a unique `rh-message-id` header (UUID v4). This is critical for tracing and deduplication downstream.
+- The Kafka topic is `platform.notifications.ingress`, configured as the `egress` channel. The channel name "egress" refers to outbound from this gateway.
+
+## REST Client Resilience
+
+### Retry Configuration
+
+All `RestValidationClient` and `RestInternalClient` methods use `@Retry(maxRetries = 5)` from MicroProfile Fault Tolerance. This means a failing backend call will be attempted 6 times total (1 initial + 5 retries).
+
+### Rules
+
+- Account for retry multiplication in capacity planning: a single inbound request can generate up to 6 backend calls if the backend is unhealthy.
+- The REST client URL is resolved from Clowder config (`clowder.endpoints.notifications-backend-service.url`) with localhost fallback. Ensure Clowder config is present in deployed environments.
+
+## Metrics
+
+### Counter Conventions
+
+Three Micrometer counters track request flow:
+
+| Counter | When Incremented |
+|---|---|
+| `notifications.gw.received` | Every incoming POST to `/notifications` |
+| `notifications.gw.forwarded` | After successful Kafka ack |
+| `notifications.gw.failed.requests` | On validation or Kafka failure, tagged with `status_code` |
+
+### Rules
+
+- The failure counter uses dynamic tags (`status_code`). Be aware this creates a new time series per distinct HTTP status code. This is bounded in practice (400, 503) but do not add unbounded tag values.
+- Counters are initialized in the constructor (`GwResource(MeterRegistry)`), not via `@PostConstruct`. Follow this pattern for counters that do not need dynamic tags.
+- For counters with dynamic tags, use `meterRegistry.counter(name, Tags.of(...)).increment()` inline as done in `incrementFailuresCounter()`.
+
+## Access Log Filtering
+
+Health and metrics endpoints are filtered from access logs to reduce log volume:
+
+```java
+public static final String FILTER_REGEX = ".*(/health(/\\w+)?|/metrics) HTTP/[0-9].[0-9]\" 200.*\\n?";
+```
+
+This filter is applied via `java.util.logging.Logger.setFilter()` on the `access_log` category. If you add new infrastructure endpoints that generate high-frequency traffic, add them to this regex.
+
+## Request Processing Cost
+
+A single `POST /notifications` in the default (non-bulk) mode performs:
+1. Base64 decode + JSON deserialize of `x-rh-identity` header
+2. Bean validation of the request body
+3. REST call to backend for certificate validation (if X509/ServiceAccount identity)
+4. REST call to backend for BAET validation (cached 10 min)
+5. Action serialization via `Parser.encode()`
+6. Kafka produce + synchronous ack wait (up to 60s)
+
+In bulk mode, steps 3-4 are replaced by in-memory lookups against data refreshed every hour.
+
+## Configuration Properties Summary
+
+| Property | Default | Impact |
+|---|---|---|
+| `notifications.kafka-callback-timeout-seconds` | 60 | Max HTTP response time for forwarded messages |
+| `notifications.bulk-caches.enabled` | false | Switches between per-request and bulk validation |
+| `notifications.allow-list.enabled` | false | Enables org ID allow-listing for stage sources |
+| `notifications.emails.internal-only.enabled` | true | Restricts recipient emails to `@redhat.com` |

--- a/docs/security-guidelines.md
+++ b/docs/security-guidelines.md
@@ -1,0 +1,117 @@
+# Security Guidelines
+
+## Authentication Model
+
+### x-rh-identity Header
+This gateway uses a custom `HttpAuthenticationMechanism` (`RHIdAuthMechanism`) that extracts identity from the Base64-encoded `x-rh-identity` HTTP header. The header is set by the platform (3scale/Turnpike) before requests reach this service -- the gateway does NOT perform cryptographic verification of the header itself.
+
+- All JAX-RS resources automatically go through Quarkus Security, which invokes the `RHIdAuthMechanism`.
+- The `RhIdPrincipal` provides access to both a subject (via `getName()`) and a type (via `getType()`). Always check `principal.getType()` when making authorization decisions -- different identity types (X509, ServiceAccount, Associate) have different trust levels.
+- If the `x-rh-identity` header is missing or malformed, `HeaderHelper.getRhIdFromString` returns `Optional.empty()` and the principal defaults to subject `"-unset-"` with type `"-unset-"`. The request is NOT rejected at the auth layer. Validation happens downstream.
+
+### Supported Identity Types
+The `Identity` class uses Jackson polymorphic deserialization with three subtypes:
+
+| Type | Class | Subject extracted from |
+|---|---|---|
+| `X509` | `X509Identity` | `x509.subject_dn` |
+| `Associate` | `SamlIdentity` | `associate.email` |
+| `ServiceAccount` | `RhServiceAccountIdentity` | `service_account.username` |
+
+When adding a new identity type, register it as a `@JsonSubTypes.Type` on the `Identity` class. Unknown types will cause deserialization to fail silently (returns empty optional).
+
+## Authorization
+
+### Source Environment and Allow-List
+Requests from X509 or ServiceAccount identities undergo source environment resolution. If the source is `"stage"`, the org ID must appear in the allow-list or the request is rejected with HTTP 403.
+
+- The allow-list is configured via `notifications.allow-list.enabled` and `notifications.allow-list.org-ids`.
+- This mechanism prevents staging services from sending notifications to production customers. Never disable this in production.
+- When `notifications.bulk-caches.enabled` is `true`, source environments are resolved from a locally cached list (refreshed hourly). When `false`, each request calls `RestValidationClient.validateCertificate()`.
+
+### Internal-Only Email Restriction
+When `notifications.emails.internal-only.enabled` is `true` (default), all email addresses in `recipients.emails` must end with `@redhat.com`. Non-matching addresses cause an HTTP 400 rejection. The check is case-insensitive after trimming.
+
+## Input Validation
+
+### RestAction Constraints
+All incoming notification payloads are validated via Jakarta Bean Validation on `RestAction`:
+
+- `bundle`, `application`, `eventType`: Must match `[a-z][a-z_0-9-]*` -- lowercase only, must start with a letter.
+- `orgId`: Required, non-empty, must be a positive number (string type allows leading zeros).
+- `accountId`: Optional but if present must be a positive number.
+- `timestamp`: Validated by custom `@ISO8601Timestamp` constraint using `DateTimeFormatter.ISO_LOCAL_DATE_TIME`.
+- `events`: Required, non-null list. Each `RestEvent.payload` must be non-null and non-empty.
+
+When adding new fields to `RestAction`, always add appropriate Jakarta Validation annotations. Do not rely solely on downstream validation.
+
+### Email Format Validation
+`RestRecipient.emails` entries are validated against the regex `^\S+@\S+\.\S+$`. This is a structural check only, not a deliverability check.
+
+### Event Type Validation
+Before forwarding to Kafka, the gateway validates that the `(bundle, application, eventType)` tuple exists by calling the notifications-backend service (or checking the local cache when bulk caches are enabled). Invalid tuples return HTTP 400.
+
+## Log Safety
+
+### Anti-Injection Protection
+`IncomingRequestInterceptor` sanitizes URIs before logging using `ANTI_INJECTION_PATTERN` which strips `\n`, `\r`, and `\t` characters. This prevents log forging/poisoning attacks.
+
+When adding new log statements that include user-supplied data, sanitize the input or use parameterized logging (`Log.infof` with `%s` placeholders). Never concatenate raw user input into log messages.
+
+### Access Log Filtering
+Health and metrics endpoint requests (`/health`, `/metrics`) are filtered from access logs to reduce noise. The filter is in `NotificationsGwApp.initAccessLogFilter()`.
+
+## Secrets Management
+
+### Configuration Sources
+- Secrets and service URLs are injected via Clowder (`clowder-quarkus-config-source`), not hardcoded.
+- `application.properties` contains only defaults and placeholder values for local development.
+- CloudWatch credentials (`access-key-id`, `access-key-secret`) have `"placeholder"` defaults -- real values come from Clowder at runtime.
+- Never add real credentials to `application.properties` or test resource files.
+
+### Kafka SSL
+The property `feature-flags.expose-kafka-ssl-config-keys.enabled=true` allows Clowder to inject Kafka SSL configuration. Do not disable this in production deployments.
+
+## Downstream Communication
+
+### REST Client Security
+- `RestValidationClient` and `RestInternalClient` communicate with `notifications-backend` over internal service mesh paths (`/internal/validation/*`, `/internal/gw/*`).
+- Both clients use `@Retry(maxRetries = 5)` for resilience.
+- The backend URL is resolved from Clowder: `quarkus.rest-client.notifications-backend.url=${clowder.endpoints.notifications-backend-service.url}`.
+- When the backend returns non-400 errors, the gateway returns HTTP 503 to callers and does NOT leak internal error details.
+
+### Kafka Message Headers
+Every outgoing Kafka message includes:
+- `rh-message-id`: A random UUID v4 for traceability.
+- `rh-source-environment`: Added only when the source environment is identified (X509/ServiceAccount from a known source).
+
+Never remove the `rh-message-id` header -- downstream consumers depend on it for deduplication and tracing.
+
+## Caching
+
+Security-relevant data is cached with the following TTLs:
+
+| Cache | TTL | Purpose |
+|---|---|---|
+| `baet-validation` | 10 minutes | Per-request event type validation results |
+| `certificate-validation` | 10 minutes | Per-request certificate validation results |
+| `get-baets` | 1 hour | Bulk event type list (when bulk caches enabled) |
+| `get-certificates` | 1 hour | Bulk certificate/source environment list |
+
+Cache invalidation does not happen on-demand. If a certificate or event type is revoked, it may remain valid for up to the TTL duration. When adjusting TTLs, balance security responsiveness against backend load.
+
+## Testing Security Features
+
+### Identity in Tests
+Use `TestHelpers.encodeIdentityInfo(tenant, username)` to create Base64-encoded `x-rh-identity` headers for tests. This creates an X509-type identity with the username as the subject DN.
+
+Every test request to authenticated endpoints must include the `x-rh-identity` header. Tests without this header exercise the `"-unset-"` fallback path, not the real authentication flow.
+
+### Allow-List Tests
+`AllowListTest` covers the matrix of allow-list enabled/disabled, stage/prod source, and known/unknown org IDs. When modifying the allow-list logic, ensure all combinations remain covered.
+
+### Validation Tests
+`RestActionValidationTest` tests Bean Validation constraints independently of the HTTP layer using the `Validator` API. When adding new constraints to `RestAction`, add corresponding unit tests in this class.
+
+## Ephemeral Environment Considerations
+In ephemeral environments (no 3scale), the gateway receives requests on `/api/notifications-gw/notifications` instead of `/notifications`. The `IncomingRequestInterceptor` rewrites this path. Do not add security logic that depends on the request path, as it may differ between environments.

--- a/docs/testing-guidelines.md
+++ b/docs/testing-guidelines.md
@@ -1,0 +1,152 @@
+# Testing Guidelines
+
+## Test Stack
+
+| Component | Library/Tool |
+|-----------|-------------|
+| Framework | JUnit 5 (via `quarkus-junit5-mockito`) |
+| HTTP testing | REST-assured |
+| Mocking | Mockito (`@InjectMock`, `@InjectSpy`) |
+| External services | MockServer (`mockserver-netty`) |
+| Kafka | SmallRye In-Memory Connector (`smallrye-reactive-messaging-in-memory`) |
+| Async assertions | Awaitility |
+| Bean validation | Jakarta Validation (`Validation.buildDefaultValidatorFactory()`) |
+
+## Test Categories
+
+### 1. Integration tests (`@QuarkusTest`)
+Tests that require CDI, REST endpoints, Kafka messaging, or REST client mocking **must** use `@QuarkusTest`. If the test also needs Kafka or MockServer, add the lifecycle resource:
+
+```java
+@QuarkusTest
+@QuarkusTestResource(TestLifecycleManager.class)
+public class MyFeatureTest {
+```
+
+Only add `@QuarkusTestResource` when the test actually interacts with Kafka egress or MockServer. Tests like `NonApplicationRootPathTest` and `AllowListTest` use `@QuarkusTest` alone (with `@InjectMock` for REST clients).
+
+### 2. Plain unit tests (no annotation)
+Tests that validate POJOs, parsing logic, regex patterns, or bean validation constraints run without Quarkus. Examples: `RestActionValidationTest`, `IdentityTest`, `NotificationsGwAppTest`. Do not add `@QuarkusTest` to these -- it slows execution for no benefit.
+
+## Test Lifecycle
+
+### `TestLifecycleManager`
+This is the single `QuarkusTestResourceLifecycleManager` for the project. It:
+1. Starts MockServer via `MockServerLifecycleManager.start()`
+2. Configures mock expectations for the `/internal/validation/baet` endpoint
+3. Switches the `egress` Kafka outgoing channel to the in-memory connector
+4. Returns override properties that Quarkus applies at startup
+
+When adding new external service routes that MockServer should handle, add them in `TestLifecycleManager.setupMockServer()`.
+
+### `MockServerLifecycleManager`
+A static utility wrapping `ClientAndServer`. Logging is disabled by default. Enable it with `-Dmockserver.logLevel=WARN` (or `INFO`/`DEBUG`/`TRACE`).
+
+## Mocking REST Clients
+
+REST clients (`RestValidationClient`, `RestInternalClient`) are `@ApplicationScoped` interfaces using `@RegisterRestClient`. Mock them in tests with:
+
+```java
+@InjectMock
+@RestClient
+RestValidationClient restValidationClient;
+```
+
+Use `@InjectSpy` when you need to verify calls while keeping real behavior for some methods. Always reset mocks between test iterations when looping over multiple scenarios in a single test method.
+
+## Kafka / Messaging Testing
+
+Kafka is replaced by the SmallRye in-memory connector in tests. Access the sink via:
+
+```java
+@Inject @Any
+InMemoryConnector inMemoryConnector;
+```
+
+Rules:
+- Always clear the sink in `@BeforeEach` to avoid cross-test contamination.
+- Use Awaitility to wait for async message delivery -- never assert on sink size synchronously:
+  ```java
+  await().atMost(Duration.ofSeconds(10L)).until(() -> inMemorySink.received().size() > 0);
+  ```
+- After receiving a message, verify Kafka headers (e.g., `rh-message-id`) via `KafkaMessageMetadata`.
+- Deserialize the payload with `Json.decodeValue(message.getPayload(), Map.class)`.
+
+## Quarkus Cache in Tests
+
+When testing bulk-cache behavior, invalidate caches explicitly between scenarios:
+
+```java
+@CacheName("get-baets")
+Cache cacheBaet;
+
+cacheBaet.invalidateAll().await().indefinitely();
+```
+
+Use `@CacheInvalidateAll(cacheName = "...")` on `@BeforeEach` methods for automatic per-test cache clearing.
+
+## Identity / Authentication
+
+All requests to secured endpoints require an `x-rh-identity` header. Use the helper:
+
+```java
+String identity = TestHelpers.encodeIdentityInfo("test", "user");
+given().header("x-rh-identity", identity)...
+```
+
+This produces a Base64-encoded X509 identity JSON. If you need SAML or ServiceAccount identity types, construct the JSON manually (see `IdentityTest` for the format).
+
+## REST-assured Conventions
+
+- Use static imports: `given()`, `when()`, `JSON` content type.
+- POST payloads as domain objects (`RestAction`) -- Jackson serialization is automatic.
+- Assert status codes and extract response as `String`, then parse with `JsonObject`:
+  ```java
+  String responseBody = given()
+      .body(action)
+      .header("x-rh-identity", identity)
+      .contentType(JSON)
+      .when().post("/notifications/")
+      .then().statusCode(200)
+      .extract().asString();
+  assertEquals("success", new JsonObject(responseBody).getString("result"));
+  ```
+
+## Bean Validation Tests
+
+For testing `RestAction` validation constraints without starting Quarkus:
+
+```java
+ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+Validator validator = factory.getValidator();
+Set<ConstraintViolation<RestAction>> violations = validator.validate(action);
+assertEquals(0, violations.size(), violations.toString());
+```
+
+## Naming Conventions
+
+- Test classes: `<Subject>Test.java` (e.g., `GwResourceTest`, `AllowListTest`)
+- Test methods: descriptive camelCase starting with `test` or `should`, or a concise name like `noEmptyContent`
+- Helper methods within test classes are `private` or package-private and reused across test methods in the same class
+
+## File Organization
+
+All test classes live in a single flat package: `com.redhat.cloud.notifications`. There are no sub-packages in the test tree.
+
+| File | Purpose |
+|------|---------|
+| `TestLifecycleManager` | Quarkus test resource: starts MockServer, configures in-memory Kafka |
+| `MockServerLifecycleManager` | Static MockServer wrapper (start/stop/getClient) |
+| `TestHelpers` | Identity header encoding utility |
+
+## Configuration
+
+Test-specific properties are set via the `%test.` profile prefix in `application.properties`. Additional overrides come from `TestLifecycleManager.start()` return value (MockServer URL, in-memory connector config). Do not create a separate `application-test.properties` file.
+
+## Running Tests
+
+```bash
+./mvnw test
+```
+
+No Docker or Testcontainers containers are launched at runtime -- MockServer is started in-process via `ClientAndServer.startClientAndServer()` and Kafka is replaced by the in-memory connector.


### PR DESCRIPTION
This PR was generated by the `/agent-readiness` Claude skill from https://github.com/gwenneg/claude-engineering-toolkit.

## Summary by Sourcery

Add AI-agent-focused documentation and configuration to guide testing, integration, performance, security, error handling, and API contract practices for the notifications gateway.

Documentation:
- Add detailed testing guidelines describing test stack, categories, lifecycle management, and conventions for Kafka, REST clients, identity, and configuration.
- Add integration guidelines covering Kafka messaging contracts, REST client behavior, caching, authentication, allow-listing, response formats, metrics, and integration testing patterns.
- Add performance guidelines outlining caching strategies, thread-safety considerations, Kafka producer behavior, REST client resilience, metrics usage, and request cost.
- Add security guidelines documenting authentication via x-rh-identity, authorization rules, validation, logging safety, secrets management, caching TTLs, and security testing.
- Add error handling guidelines standardizing response envelopes, HTTP status usage, validation flows, REST client and Kafka error handling, logging levels, and metrics for failures.
- Add API contracts guidelines for REST paths, models, validation rules, OpenAPI usage, request interception, REST client conventions, and internal email restrictions.
- Add an AGENTS index file pointing AI agents to the new domain-specific guideline documents.

Chores:
- Add CodeRabbit configuration to treat the new guideline documents as code review knowledge base and add a CLAUDE metadata file referencing the agents index.