### PR TITLE
Update default IMAGE param to use new repo

### DIFF
--- a/.rhcicd/clowdapp.yaml
+++ b/.rhcicd/clowdapp.yaml
@@ -104,7 +104,7 @@ parameters:
   required: true
 - name: IMAGE
   description: Image URL
-  value: quay.io/cloudservices/notifications-gw
+  value: quay.io/redhat-services-prod/hcc-integrations-tenant/notifications/notifications-gw
 - name: IMAGE_TAG
   description: Image tag
   value: latest


### PR DESCRIPTION
## Summary by Sourcery

Deployment:
- Change the default IMAGE parameter to use the new quay.io redhat-services-prod notifications-gw image path.