### PR TITLE
Stop bumping Maven dependencies with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,6 @@
 
 version: 2
 updates:
-  - package-ecosystem: "maven"
-    directory: "/"
-    schedule:
-      interval: "daily"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Konflux is already doing it.

## Summary by Sourcery

Disable Maven dependency update automation in Dependabot configuration and adjust GitHub Actions update scheduling.

CI:
- Remove Dependabot configuration for Maven dependencies so they are no longer automatically bumped.
- Stop explicitly scheduling weekly Dependabot updates for GitHub Actions in the CI configuration.