### PR TITLE
Refine Renovate automerge strategy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>konflux-ci/mintmaker//config/renovate/renovate.json"],
-  "baseBranches": ["main"],
-  "tekton": {
-    "schedule": ["at any time"]
-  }
-}

--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>konflux-ci/mintmaker//config/renovate/renovate.json"],
+  "baseBranchPatterns": ["main"],
+  "tekton": {
+    "schedule": ["at any time"]
+  },
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["patch", "minor"],
+      // Delay before automerging, to reduce the risk of merging a compromised release (supply-chain attacks are often caught and pulled within days of publishing).
+      "minimumReleaseAge": "3 days",
+      "automerge": true
+    },
+    {
+      "matchManagers": ["maven"],
+      "matchUpdateTypes": ["patch", "minor"],
+      // Delay before automerging, to reduce the risk of merging a compromised release (supply-chain attacks are often caught and pulled within days of publishing).
+      "minimumReleaseAge": "3 days",
+      "automerge": true
+    },
+    {
+      // Quarkus bumps need manual review so we stick to the latest LTS instead of the newest minor. See https://quarkus.io/releases/.
+      "matchManagers": ["maven"],
+      "matchPackageNames": ["io.quarkus*"],
+      "automerge": false
+    },
+    {
+      // Maven wrapper version bumps (.mvn/wrapper/maven-wrapper.properties, mvnw) need manual review.
+      "matchManagers": ["maven-wrapper"],
+      "automerge": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Automerge Maven and GitHub Actions **patch** and **minor** updates, gated by a 3-day `minimumReleaseAge` to reduce the risk of merging a compromised release before the community catches it.
- Exclude Quarkus (`io.quarkus*`) from automerge entirely — platform bumps need manual review so we stick to the latest LTS stream instead of jumping to the newest minor (see https://quarkus.io/releases/).
- Exclude Maven wrapper (`maven-wrapper` manager) bumps from automerge — wrapper version changes need manual review too.
- Renamed `renovate.json` to `renovate.jsonc` so the reasoning above can live as inline comments.
- Replaced the deprecated `baseBranches` option with `baseBranchPatterns`.

## Test plan
- [ ] Confirm Renovate picks up `renovate.jsonc` (schema-validated locally against the current Renovate schema).
- [ ] Watch the next few Renovate PRs to confirm patch/minor Maven and GitHub Actions updates automerge after 3 days, while Quarkus and maven-wrapper PRs stay manual.

## Summary by Sourcery

Enhancements:
- Rename the Renovate configuration file from JSON to JSONC to support inline commentary on update and automerge policies.