### PR TITLE
Enable GitHub and OSV vulnerability alerts in Renovate

### DIFF
--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -2,6 +2,12 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>konflux-ci/mintmaker//config/renovate/renovate.json"],
   "baseBranchPatterns": ["main"],
+  // Raise fix PRs for vulnerabilities found in GitHub's advisory database (needs Dependabot alerts enabled on the repo).
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  // Raise fix PRs for vulnerabilities found in OSV.dev. Its coverage differs from GitHub's, so we need both.
+  "osvVulnerabilityAlerts": true,
   "tekton": {
     "schedule": ["at any time"]
   },


### PR DESCRIPTION
## Summary
- Enable `vulnerabilityAlerts` so Renovate raises fix PRs for vulnerabilities found in GitHub's advisory database (requires Dependabot alerts on the repo).
- Enable `osvVulnerabilityAlerts` so Renovate also raises fix PRs for vulnerabilities found in OSV.dev.
- Both are kept since their coverage differs (each source has advisories the other doesn't have yet), so running both maximizes how quickly a vulnerability turns into a fix PR.

Note: neither option blocks merges by itself — they only control whether/how fast Renovate opens a fix PR. Actual merge gating still relies on the existing Grype scan in `.github/workflows/platsec-gw.yml`.

## Test plan
- [ ] Confirm `renovate.jsonc` is still valid JSONC (no CI validation configured for this repo)

## Summary by Sourcery

Enable vulnerability alert-based fix PRs in Renovate by turning on both GitHub advisory and OSV.dev vulnerability integrations.

Enhancements:
- Configure Renovate to create fix PRs based on GitHub Dependabot vulnerability alerts.
- Configure Renovate to create fix PRs based on OSV.dev vulnerability alerts.